### PR TITLE
merge: (#3) Dockerfile 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM amazoncorretto:17 AS build
+COPY . .
+RUN chmod +x gradlew && ./gradlew bootJar
+
+FROM amazoncorretto:17-alpine
+COPY --from=build build/libs/*.jar /app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]


### PR DESCRIPTION
## #️연관된 이슈

#3 

## 작업 내용

Docker 이미지 빌드를 위한 Dockerfile 추가

- 멀티 스테이지 빌드 적용하여 이미지 사이즈 최소화
- amazoncorretto:17 기반 이미지 사용
- gradlew를 통해 jar 파일 생성 후 amazoncorretto:17-alpine 이미지에 복사