### PR TITLE
refactor: (#12) API 권한별 접근 경로 수정

### DIFF
--- a/src/main/kotlin/org/example/root_be/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/example/root_be/global/config/SecurityConfig.kt
@@ -19,7 +19,6 @@ class SecurityConfig(
     private val objectMapper: ObjectMapper,
     private val jwtTokenProvider: JwtTokenProvider
 ) {
-
     @Bean
     fun filterChain(http: HttpSecurity, corsConfigurationSource: CorsConfigurationSource): SecurityFilterChain {
         http
@@ -31,49 +30,48 @@ class SecurityConfig(
                 it
                     .requestMatchers("/auth/**").permitAll()
 
-                    //student
-                    .requestMatchers(
-                        HttpMethod.GET,
-                        "/user/mypage",
-                        "/user/volunteer-verification"
+                    // Both ADMIN and STUDENT endpoints
+                    .requestMatchers(HttpMethod.GET,
+                        "/users/me",
+                        "/posts",
+                        "/posts/{postId}",
+                        "/schedules",
+                        "/schedules/{date}",
+                        "/notifications"
+                    ).hasAnyRole("ADMIN", "STUDENT")
+
+                    // STUDENT only endpoints
+                    .requestMatchers(HttpMethod.GET,
+                        "/users/me/volunteer"
                     ).hasRole("STUDENT")
                     .requestMatchers(HttpMethod.POST,
-                        "/user/volunteer-application",
-                        "/user/qrcode-scan"
+                        "/volunteer/applications",
+                        "/qr/scan"
                     ).hasRole("STUDENT")
 
-                    //admin
+                    // ADMIN only endpoints
                     .requestMatchers(HttpMethod.GET,
-                        "/admin/qrcode-creation",
-                        "/admin/mypage",
-                        "/admin/inquiry/**",
-                        "/admin/volunteer-application/**"
+                        "/users",
+                        "/users/volunteer/hours",
+                        "/volunteer/applications/{postId}"
                     ).hasRole("ADMIN")
                     .requestMatchers(HttpMethod.POST,
-                        "/admin/volunteer-hours/grants",
-                        "/admin/role-assignment/**",
-                        "/admin/volunteer-application/request",
-                        "/admin/volunteer-posts/creation",
-                        "/admin/schedules",
+                        "/users/volunteer/hours",
+                        "/posts",
+                        "/volunteer/applications/status",
+                        "/volunteer/roles/{postId}",
+                        "/schedules",
+                        "/qr",
                         "/notifications"
                     ).hasRole("ADMIN")
                     .requestMatchers(HttpMethod.PATCH,
-                        "/admin/volunteer-posts/**",
-                        "/admin/schedules/**"
+                        "/posts/{postId}",
+                        "/schedules/{date}"
                     ).hasRole("ADMIN")
                     .requestMatchers(HttpMethod.DELETE,
-                        "/admin/volunteer-posts/**",
-                        "/admin/schedules/**"
+                        "/posts/{postId}",
+                        "/schedules/{date}"
                     ).hasRole("ADMIN")
-
-                    //student, admin
-                    .requestMatchers(HttpMethod.GET,
-                        "/schedules/inquiry",
-                        "/schedules/**",
-                        "/volunteer-posts",
-                        "/volunteer-posts/**",
-                        "/notifications"
-                    ).hasAnyRole("STUDENT", "ADMIN")
 
                     .anyRequest().authenticated()
             }


### PR DESCRIPTION
## #️연관된 이슈

#12 

## 작업 내용

API 엔드포인트 구조 변경 및 권한별 접근 경로 수정

- 기존 student, admin으로 나뉘어있던 api 경로를 users, posts, schedules, volunteer, qr, notifications 로 변경
- 각각의 변경된 api 에 대한 권한 설정 수정
- ADMIN, STUDENT 두 role 모두 접근 가능한 api는 hasAnyRole 메소드를 통해 권한 부여
- STUDENT, ADMIN role 각각 단독 접근 api 는 hasRole 메소드를 통해 권한 부여
