### PR TITLE
merge: (#18) API 권한 설정 수정

### DIFF
--- a/src/main/kotlin/org/example/root_be/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/example/root_be/global/config/SecurityConfig.kt
@@ -30,7 +30,7 @@ class SecurityConfig(
                 it
                     .requestMatchers("/auth/**").permitAll()
 
-                    // Both ADMIN and STUDENT endpoints
+                    // ADMIN, STUDENT 공통 엔드포인트
                     .requestMatchers(HttpMethod.GET,
                         "/users/me",
                         "/posts",
@@ -40,25 +40,25 @@ class SecurityConfig(
                         "/notifications"
                     ).hasAnyRole("ADMIN", "STUDENT")
 
-                    // STUDENT only endpoints
+                    // STUDENT 전용 엔드포인트
                     .requestMatchers(HttpMethod.GET,
                         "/users/me/volunteer"
                     ).hasRole("STUDENT")
                     .requestMatchers(HttpMethod.POST,
-                        "/volunteer/applications",
+                        "/volunteer/applications/{postId}",
                         "/qr/scan"
                     ).hasRole("STUDENT")
 
-                    // ADMIN only endpoints
+                    // ADMIN 전용 엔드포인트
                     .requestMatchers(HttpMethod.GET,
                         "/users",
-                        "/users/volunteer/hours",
+                        "/users/{userId}/volunteer",
                         "/volunteer/applications/{postId}"
                     ).hasRole("ADMIN")
                     .requestMatchers(HttpMethod.POST,
-                        "/users/volunteer/hours",
+                        "/users/volunteer",
                         "/posts",
-                        "/volunteer/applications/status",
+                        "/volunteer/applications/{postId}/status",
                         "/volunteer/roles/{postId}",
                         "/schedules",
                         "/qr",


### PR DESCRIPTION


## #️연관된 이슈

#18 

## 작업 내용

API 엔드포인트 권한 설정을 수정합니다.

- ADMIN, STUDENT 공통 엔드포인트, STUDENT 전용 엔드포인트, ADMIN 전용 엔드포인트를 명확히 구분합니다.
- 기존 `/users/volunteer/hours` 엔드포인트를 `/users/{userId}/volunteer` (GET) 및 `/users/volunteer` (POST)로 변경합니다.
- `/volunteer/applications` 엔드포인트에 `{postId}`를 추가하고, POST 메서드는 STUDENT 전용, GET 메서드는 ADMIN 전용으로 변경합니다.
- `/volunteer/applications/status` 엔드포인트를 `/volunteer/applications/{postId}/status`로 변경합니다.
- 마이페이지 API 경로 수정 (#15) 이후 변경된 API 경로에 따라 권한 설정을 업데이트합니다.
