### PR TITLE
merge:  봉사 신청 API 구현

### DIFF
--- a/src/main/kotlin/org/example/root_be/domain/applications/domain/VolunteerApplication.kt
+++ b/src/main/kotlin/org/example/root_be/domain/applications/domain/VolunteerApplication.kt
@@ -1,0 +1,36 @@
+package org.example.root_be.domain.applications.domain
+
+import jakarta.persistence.*
+import org.example.root_be.domain.role.domain.Role
+import org.example.root_be.domain.user.domain.User
+import org.example.root_be.domain.volunteer.domain.VolunteerPost
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "volunteer_application")
+class VolunteerApplication(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    val user: User,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    val volunteerPost: VolunteerPost,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "role_id")
+    val volunteerRole: Role? = null,
+
+    @Column(nullable = false)
+    var isApplied: Boolean = false,
+
+    @Column(nullable = false)
+    var isAccepted: Boolean = false,
+
+    @Column(nullable = false)
+    val appliedAt: LocalDateTime = LocalDateTime.now()
+)

--- a/src/main/kotlin/org/example/root_be/domain/applications/domain/repository/VolunteerApplicationRepository.kt
+++ b/src/main/kotlin/org/example/root_be/domain/applications/domain/repository/VolunteerApplicationRepository.kt
@@ -1,0 +1,8 @@
+package org.example.root_be.domain.applications.domain.repository
+
+import org.example.root_be.domain.applications.domain.VolunteerApplication
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface VolunteerApplicationRepository : JpaRepository<VolunteerApplication, Long>

--- a/src/main/kotlin/org/example/root_be/domain/applications/presentation/ApplicationsController.kt
+++ b/src/main/kotlin/org/example/root_be/domain/applications/presentation/ApplicationsController.kt
@@ -1,0 +1,15 @@
+package org.example.root_be.domain.applications.presentation
+
+import org.example.root_be.domain.applications.presentation.dto.response.ApplyVolunteerResponse
+import org.example.root_be.domain.applications.service.ApplyVolunteerService
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController("/volunteer/applications")
+class ApplicationsController(
+    private val applyVolunteerService: ApplyVolunteerService,
+){
+    @PostMapping("/{postId}")
+    fun applyVolunteer(@PathVariable postId: Long): ApplyVolunteerResponse = applyVolunteerService.execute(postId)
+}

--- a/src/main/kotlin/org/example/root_be/domain/applications/presentation/dto/response/ApplyVolunteerResponse.kt
+++ b/src/main/kotlin/org/example/root_be/domain/applications/presentation/dto/response/ApplyVolunteerResponse.kt
@@ -1,0 +1,7 @@
+package org.example.root_be.domain.applications.presentation.dto.response
+
+data class ApplyVolunteerResponse(
+    val applicationId: Long,
+    val userId: Long,
+    val postId: Long
+)

--- a/src/main/kotlin/org/example/root_be/domain/applications/service/ApplyVolunteerService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/applications/service/ApplyVolunteerService.kt
@@ -5,28 +5,26 @@ import org.example.root_be.domain.applications.domain.VolunteerApplication
 import org.example.root_be.domain.applications.domain.repository.VolunteerApplicationRepository
 import org.example.root_be.domain.applications.presentation.dto.response.ApplyVolunteerResponse
 import org.example.root_be.domain.user.facade.UserFacade
-import org.example.root_be.domain.volunteer.domain.repository.VolunteerPostRepository
-import org.example.root_be.domain.volunteer.exception.VolunteerPostNotFoundException
+import org.example.root_be.domain.volunteer.facade.VolunteerFacade
 import org.springframework.stereotype.Service
 
 @Service
 class ApplyVolunteerService(
     private val volunteerApplicationRepository: VolunteerApplicationRepository,
     private val userFacade: UserFacade,
-    private val volunteerPostRepository: VolunteerPostRepository
+    private val volunteerFacade: VolunteerFacade
 ) {
     @Transactional
     fun execute(postId: Long): ApplyVolunteerResponse {
         val user = userFacade.getCurrentUser()
-        val post = volunteerPostRepository.findById(postId)
-            .orElseThrow() { VolunteerPostNotFoundException }
+        val post = volunteerFacade.getVolunteerPostById(postId)
 
-        val application = VolunteerApplication(
-            user = user,
-            volunteerPost = post
+        val savedApplication = volunteerApplicationRepository.save(
+            VolunteerApplication(
+                user = user,
+                volunteerPost = post
+            )
         )
-
-        val savedApplication = volunteerApplicationRepository.save(application)
 
         return ApplyVolunteerResponse(
             applicationId = savedApplication.id,

--- a/src/main/kotlin/org/example/root_be/domain/applications/service/ApplyVolunteerService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/applications/service/ApplyVolunteerService.kt
@@ -1,0 +1,37 @@
+package org.example.root_be.domain.applications.service
+
+import jakarta.transaction.Transactional
+import org.example.root_be.domain.applications.domain.VolunteerApplication
+import org.example.root_be.domain.applications.domain.repository.VolunteerApplicationRepository
+import org.example.root_be.domain.applications.presentation.dto.response.ApplyVolunteerResponse
+import org.example.root_be.domain.user.facade.UserFacade
+import org.example.root_be.domain.volunteer.domain.repository.VolunteerPostRepository
+import org.example.root_be.domain.volunteer.exception.VolunteerPostNotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class ApplyVolunteerService(
+    private val volunteerApplicationRepository: VolunteerApplicationRepository,
+    private val userFacade: UserFacade,
+    private val volunteerPostRepository: VolunteerPostRepository
+) {
+    @Transactional
+    fun execute(postId: Long): ApplyVolunteerResponse {
+        val user = userFacade.getCurrentUser()
+        val post = volunteerPostRepository.findById(postId)
+            .orElseThrow() { VolunteerPostNotFoundException }
+
+        val application = VolunteerApplication(
+            user = user,
+            volunteerPost = post
+        )
+
+        val savedApplication = volunteerApplicationRepository.save(application)
+
+        return ApplyVolunteerResponse(
+            applicationId = savedApplication.id,
+            userId = user.id,
+            postId = post.id
+        )
+    }
+}


### PR DESCRIPTION
## #️연관된 이슈

#29 

## 작업 내용

봉사 신청 기능을 구현한다.

- `VolunteerApplication` 엔티티 생성
- 봉사 신청 API 구현(/volunteer/applications/{postId})
- 봉사 신청 서비스 로직 구현
- 봉사 신청 응답 DTO 생성