### PR TITLE
merge: 봉사 신청 목록 조회 기능 추가

### DIFF
--- a/src/main/kotlin/org/example/root_be/domain/applications/domain/repository/VolunteerApplicationRepository.kt
+++ b/src/main/kotlin/org/example/root_be/domain/applications/domain/repository/VolunteerApplicationRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface VolunteerApplicationRepository : JpaRepository<VolunteerApplication, Long>
+interface VolunteerApplicationRepository : JpaRepository<VolunteerApplication, Long> {
+    fun findAllByVolunteerPostId(postId: Long): List<VolunteerApplication>
+}

--- a/src/main/kotlin/org/example/root_be/domain/applications/presentation/ApplicationsController.kt
+++ b/src/main/kotlin/org/example/root_be/domain/applications/presentation/ApplicationsController.kt
@@ -1,7 +1,10 @@
 package org.example.root_be.domain.applications.presentation
 
 import org.example.root_be.domain.applications.presentation.dto.response.ApplyVolunteerResponse
+import org.example.root_be.domain.applications.presentation.dto.response.GetVolunteerApplicationResponse
 import org.example.root_be.domain.applications.service.ApplyVolunteerService
+import org.example.root_be.domain.applications.service.GetVolunteerApplicationService
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
@@ -9,7 +12,15 @@ import org.springframework.web.bind.annotation.RestController
 @RestController("/volunteer/applications")
 class ApplicationsController(
     private val applyVolunteerService: ApplyVolunteerService,
+    private val getVolunteerApplicationService: GetVolunteerApplicationService,
 ){
     @PostMapping("/{postId}")
-    fun applyVolunteer(@PathVariable postId: Long): ApplyVolunteerResponse = applyVolunteerService.execute(postId)
+    fun applyVolunteer(
+        @PathVariable postId: Long
+    ): ApplyVolunteerResponse = applyVolunteerService.execute(postId)
+
+    @GetMapping("/{postId}")
+    fun getVolunteerApplication(
+        @PathVariable postId: Long
+    ): GetVolunteerApplicationResponse = getVolunteerApplicationService.execute(postId)
 }

--- a/src/main/kotlin/org/example/root_be/domain/applications/presentation/dto/response/ApplicationElement.kt
+++ b/src/main/kotlin/org/example/root_be/domain/applications/presentation/dto/response/ApplicationElement.kt
@@ -1,0 +1,10 @@
+package org.example.root_be.domain.applications.presentation.dto.response
+
+data class ApplicationElement(
+    val applicationId: Long,
+    val userId: Long,
+    val name: String,
+    val grade: Int,
+    val classNum: Int,
+    val number: Int
+)

--- a/src/main/kotlin/org/example/root_be/domain/applications/presentation/dto/response/GetVolunteerApplicationResponse.kt
+++ b/src/main/kotlin/org/example/root_be/domain/applications/presentation/dto/response/GetVolunteerApplicationResponse.kt
@@ -1,0 +1,5 @@
+package org.example.root_be.domain.applications.presentation.dto.response
+
+data class GetVolunteerApplicationResponse(
+    val applications: List<ApplicationElement>
+)

--- a/src/main/kotlin/org/example/root_be/domain/applications/service/GetVolunteerApplicationService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/applications/service/GetVolunteerApplicationService.kt
@@ -1,0 +1,29 @@
+package org.example.root_be.domain.applications.service
+
+import jakarta.transaction.Transactional
+import org.example.root_be.domain.applications.domain.repository.VolunteerApplicationRepository
+import org.example.root_be.domain.applications.presentation.dto.response.ApplicationElement
+import org.example.root_be.domain.applications.presentation.dto.response.GetVolunteerApplicationResponse
+import org.springframework.stereotype.Service
+
+@Service
+class GetVolunteerApplicationService(
+    private val volunteerApplicationRepository: VolunteerApplicationRepository,
+) {
+    @Transactional
+    fun execute(postId: Long): GetVolunteerApplicationResponse {
+        val applications = volunteerApplicationRepository.findAllByVolunteerPostId(postId)
+            .map { application ->
+                ApplicationElement(
+                    applicationId = application.id,
+                    userId = application.user.id,
+                    grade = application.user.grade,
+                    number = application.user.num,
+                    classNum = application.user.classNum,
+                    name = application.user.name
+                )
+            }
+
+        return GetVolunteerApplicationResponse(applications)
+    }
+}


### PR DESCRIPTION


## #️연관된 이슈

#34 

## 작업 내용

봉사 게시글에 대한 신청 목록을 조회하는 기능을 추가

- 특정 게시글에 대한 신청 목록을 조회하는 API 추가
- ApplicationElement, GetVolunteerApplicationResponse DTO 추가
- VolunteerApplicationRepository에 게시글 ID로 신청 목록을 조회하는 메서드 추가
- 이전에는 봉사 신청만 가능했지만, 이제 신청 목록 조회 기능을 통해 봉사 신청 현황을 확인할 수 있음