### PR TITLE
merge: 학생 봉사활동 조회 API 추가

### DIFF
--- a/src/main/kotlin/org/example/root_be/domain/user/presentation/UserController.kt
+++ b/src/main/kotlin/org/example/root_be/domain/user/presentation/UserController.kt
@@ -3,19 +3,23 @@ package org.example.root_be.domain.user.presentation
 import org.example.root_be.domain.user.presentation.dto.response.MyVolunteerActivityResponse
 import org.example.root_be.domain.user.presentation.dto.response.MypageResponse
 import org.example.root_be.domain.user.presentation.dto.response.StudentQueryResponse
+import org.example.root_be.domain.user.presentation.dto.response.StudentVolunteerActivityResponse
 import org.example.root_be.domain.user.service.MyVolunteerActivityService
 import org.example.root_be.domain.user.service.MypageService
 import org.example.root_be.domain.user.service.StudentQueryService
+import org.example.root_be.domain.user.service.StudentVolunteerActivityService
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/users")
-class UserController (
+class UserController(
     private val mypageService: MypageService,
     private val myVolunteerActivityService: MyVolunteerActivityService,
-    private val studentQueryService: StudentQueryService
+    private val studentQueryService: StudentQueryService,
+    private val studentVolunteerActivityService: StudentVolunteerActivityService
 ){
     @GetMapping("/me")
     fun mypage(): MypageResponse = mypageService.execute()
@@ -25,4 +29,9 @@ class UserController (
 
     @GetMapping
     fun studentQuery(): StudentQueryResponse = studentQueryService.execute()
+
+    @GetMapping("/{userId}/volunteer")
+    fun studentVolunteerActivity(
+        @PathVariable userId: Long
+    ): StudentVolunteerActivityResponse = studentVolunteerActivityService.execute(userId)
 }

--- a/src/main/kotlin/org/example/root_be/domain/user/presentation/dto/response/StudentVolunteerActivityResponse.kt
+++ b/src/main/kotlin/org/example/root_be/domain/user/presentation/dto/response/StudentVolunteerActivityResponse.kt
@@ -1,0 +1,5 @@
+package org.example.root_be.domain.user.presentation.dto.response
+
+data class StudentVolunteerActivityResponse(
+    val volunteerList: List<VolunteerElement>
+)

--- a/src/main/kotlin/org/example/root_be/domain/user/service/StudentVolunteerActivityService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/user/service/StudentVolunteerActivityService.kt
@@ -1,0 +1,27 @@
+package org.example.root_be.domain.user.service
+
+import jakarta.transaction.Transactional
+import org.example.root_be.domain.activity.domain.repository.VolunteerActivityRepository
+import org.example.root_be.domain.user.presentation.dto.response.StudentVolunteerActivityResponse
+import org.example.root_be.domain.user.presentation.dto.response.VolunteerElement
+import org.springframework.stereotype.Service
+
+@Service
+class StudentVolunteerActivityService(
+    private val volunteerActivityRepository: VolunteerActivityRepository,
+) {
+    @Transactional
+    fun execute(userId: Long): StudentVolunteerActivityResponse {
+        val volunteerList = volunteerActivityRepository.findAllByUserId(userId)
+            .map { activity ->
+                VolunteerElement(
+                    volunteerTime = activity.volunteerPost.time,
+                    volunteerAct = activity.volunteerPost.activityDetails
+                )
+            }
+
+        return StudentVolunteerActivityResponse(
+            volunteerList = volunteerList
+        )
+    }
+}


### PR DESCRIPTION
## #️연관된 이슈

#36 

## 작업 내용

학생의 봉사활동 목록을 조회하는 API 를 추가한다.

- `GET /users/{userId}/volunteer` 엔드포인트 생성
- `StudentVolunteerActivityResponse` DTO 생성
- `VolunteerActivityRepository` 를 통해 userId 로 봉사활동 목록 조회
- 봉사 시간, 활동 내용을 포함한 응답 반환

