### PR TITLE
feat: (#38) 봉사 신청 수락/거절 기능 추가

### DIFF
--- a/src/main/kotlin/org/example/root_be/domain/applications/exception/ApplicationNotFoundException.kt
+++ b/src/main/kotlin/org/example/root_be/domain/applications/exception/ApplicationNotFoundException.kt
@@ -1,0 +1,6 @@
+package org.example.root_be.domain.applications.exception
+
+import org.example.root_be.global.err.exception.CustomException
+import org.example.root_be.global.err.exception.ErrorCode
+
+object ApplicationNotFoundException: CustomException(ErrorCode.APPLICATION_NOT_FOUND)

--- a/src/main/kotlin/org/example/root_be/domain/applications/facade/VolunteerApplicationFacade.kt
+++ b/src/main/kotlin/org/example/root_be/domain/applications/facade/VolunteerApplicationFacade.kt
@@ -1,0 +1,16 @@
+package org.example.root_be.domain.applications.facade
+
+import org.example.root_be.domain.applications.domain.VolunteerApplication
+import org.example.root_be.domain.applications.domain.repository.VolunteerApplicationRepository
+import org.example.root_be.domain.applications.exception.ApplicationNotFoundException
+import org.springframework.stereotype.Component
+
+@Component
+class VolunteerApplicationFacade(
+    private val volunteerApplicationRepository: VolunteerApplicationRepository
+) {
+    fun getVolunteerApplicationById(applicationId: Long): VolunteerApplication {
+        return volunteerApplicationRepository.findById(applicationId)
+            .orElseThrow() { ApplicationNotFoundException }
+    }
+}

--- a/src/main/kotlin/org/example/root_be/domain/applications/presentation/ApplicationsController.kt
+++ b/src/main/kotlin/org/example/root_be/domain/applications/presentation/ApplicationsController.kt
@@ -1,18 +1,18 @@
 package org.example.root_be.domain.applications.presentation
 
+import org.example.root_be.domain.applications.presentation.dto.request.ProcessVolunteerApplicationRequest
 import org.example.root_be.domain.applications.presentation.dto.response.ApplyVolunteerResponse
 import org.example.root_be.domain.applications.presentation.dto.response.GetVolunteerApplicationResponse
 import org.example.root_be.domain.applications.service.ApplyVolunteerService
 import org.example.root_be.domain.applications.service.GetVolunteerApplicationService
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RestController
+import org.example.root_be.domain.applications.service.ProcessVolunteerApplicationService
+import org.springframework.web.bind.annotation.*
 
 @RestController("/volunteer/applications")
 class ApplicationsController(
     private val applyVolunteerService: ApplyVolunteerService,
     private val getVolunteerApplicationService: GetVolunteerApplicationService,
+    private val processVolunteerApplicationService: ProcessVolunteerApplicationService,
 ){
     @PostMapping("/{postId}")
     fun applyVolunteer(
@@ -23,4 +23,9 @@ class ApplicationsController(
     fun getVolunteerApplication(
         @PathVariable postId: Long
     ): GetVolunteerApplicationResponse = getVolunteerApplicationService.execute(postId)
+
+    @PostMapping("/status")
+    fun processVolunteerApplication(
+        @RequestBody processVolunteerApplicationRequest: ProcessVolunteerApplicationRequest
+    ) = processVolunteerApplicationService.execute(processVolunteerApplicationRequest)
 }

--- a/src/main/kotlin/org/example/root_be/domain/applications/presentation/dto/request/ProcessVolunteerApplicationRequest.kt
+++ b/src/main/kotlin/org/example/root_be/domain/applications/presentation/dto/request/ProcessVolunteerApplicationRequest.kt
@@ -1,0 +1,11 @@
+package org.example.root_be.domain.applications.presentation.dto.request
+
+import jakarta.validation.constraints.NotNull
+
+data class ProcessVolunteerApplicationRequest (
+    @NotNull(message = "신청 ID는 필수입니다.")
+    val applicationId: Long,
+
+    @NotNull(message = "수락/거절 여부는 필수입니다.")
+    val isAccepted: Boolean
+)

--- a/src/main/kotlin/org/example/root_be/domain/applications/service/ProcessVolunteerApplicationService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/applications/service/ProcessVolunteerApplicationService.kt
@@ -1,0 +1,20 @@
+package org.example.root_be.domain.applications.service
+
+import jakarta.transaction.Transactional
+import org.example.root_be.domain.applications.facade.VolunteerApplicationFacade
+import org.example.root_be.domain.applications.presentation.dto.request.ProcessVolunteerApplicationRequest
+import org.springframework.stereotype.Service
+
+@Service
+class ProcessVolunteerApplicationService(
+    private val volunteerApplicationFacade: VolunteerApplicationFacade,
+) {
+    @Transactional
+    fun execute(
+        processVolunteerApplicationRequest: ProcessVolunteerApplicationRequest
+    ) {
+        volunteerApplicationFacade.getVolunteerApplicationById(
+            processVolunteerApplicationRequest.applicationId
+        ).isAccepted = processVolunteerApplicationRequest.isAccepted
+    }
+}

--- a/src/main/kotlin/org/example/root_be/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/example/root_be/global/config/SecurityConfig.kt
@@ -58,7 +58,7 @@ class SecurityConfig(
                     .requestMatchers(HttpMethod.POST,
                         "/users/volunteer",
                         "/posts",
-                        "/volunteer/applications/{postId}/status",
+                        "/volunteer/applications/status",
                         "/volunteer/roles/{postId}",
                         "/schedules",
                         "/qr",

--- a/src/main/kotlin/org/example/root_be/global/err/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/example/root_be/global/err/exception/ErrorCode.kt
@@ -11,5 +11,6 @@ enum class ErrorCode(
     USER_NOT_FOUND("User Not Found", 404),
     INVALID_PASSWORD("Invalid Password", 401),
     FEIGN_BAD_REQUEST("External API request is invalid.", 400),
-    FEIGN_SERVER_ERROR("An external server error occurred.", 500)
+    FEIGN_SERVER_ERROR("An external server error occurred.", 500),
+    APPLICATION_NOT_FOUND("Application Not Found", 404),
 }


### PR DESCRIPTION
## #️연관된 이슈

#38 

## 작업 내용

봉사 신청을 관리자가 수락/거절 할 수 있는 기능을 추가합니다.

- 봉사 신청 수락/거절 API 추가
- ApplicationNotFoundException 추가
- VolunteerApplicationFacade 추가
- SecurityConfig 수정
- ErrorCode APPLICATION_NOT_FOUND 추가

