### PR TITLE
merge: 학생 봉사활동 기록 추가 API 구현

### DIFF
--- a/src/main/kotlin/org/example/root_be/domain/activity/domain/VolunteerActivity.kt
+++ b/src/main/kotlin/org/example/root_be/domain/activity/domain/VolunteerActivity.kt
@@ -1,8 +1,9 @@
 package org.example.root_be.domain.activity.domain
 
 import jakarta.persistence.*
+import org.example.root_be.domain.detail.domain.VolunteerDetail
 import org.example.root_be.domain.user.domain.User
-import org.example.root_be.domain.post.domain.VolunteerPost
+
 import java.time.LocalDateTime
 
 @Entity
@@ -17,11 +18,11 @@ class VolunteerActivity(
     val user: User,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id", nullable = false)
-    val volunteerPost: VolunteerPost,
+    @JoinColumn(name = "detail_id", nullable = false)
+    val volunteerDetail: VolunteerDetail,
 
     @Column(nullable = false)
-    val activityDate: LocalDateTime,
+    val activityDate: LocalDateTime = LocalDateTime.now(),
 
     @Column(nullable = false)
     val createdAt: LocalDateTime = LocalDateTime.now()

--- a/src/main/kotlin/org/example/root_be/domain/detail/domain/VolunteerDetail.kt
+++ b/src/main/kotlin/org/example/root_be/domain/detail/domain/VolunteerDetail.kt
@@ -1,0 +1,28 @@
+package org.example.root_be.domain.detail.domain
+
+import jakarta.persistence.*
+import org.example.root_be.domain.activity.domain.VolunteerActivity
+import org.example.root_be.domain.post.domain.VolunteerPost
+
+@Entity
+@Table(name = "volunteer_detail")
+class VolunteerDetail(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @Column(nullable = false)
+    val activityDetails: String,
+
+    @Column(nullable = false)
+    val place: String,
+
+    @Column(nullable = false)
+    val time: String,
+
+    @OneToOne(mappedBy = "volunteerDetail")
+    val volunteerPost: VolunteerPost? = null,
+
+    @OneToMany(mappedBy = "volunteerDetail")
+    val volunteerActivities: List<VolunteerActivity> = mutableListOf()
+)

--- a/src/main/kotlin/org/example/root_be/domain/detail/domain/repository/VolunteerDetailRepository.kt
+++ b/src/main/kotlin/org/example/root_be/domain/detail/domain/repository/VolunteerDetailRepository.kt
@@ -1,0 +1,8 @@
+package org.example.root_be.domain.detail.domain.repository
+
+import org.example.root_be.domain.detail.domain.VolunteerDetail
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface VolunteerDetailRepository : JpaRepository<VolunteerDetail, Long>

--- a/src/main/kotlin/org/example/root_be/domain/user/domain/User.kt
+++ b/src/main/kotlin/org/example/root_be/domain/user/domain/User.kt
@@ -31,4 +31,8 @@ class User(
 
     @Column(name = "total_volunteer_time", nullable = false)
     var totalVolunteerTime: Int
-)
+){
+    fun addVolunteerTime(time: Int) {
+        this.totalVolunteerTime += time
+    }
+}

--- a/src/main/kotlin/org/example/root_be/domain/user/domain/repository/UserRepository.kt
+++ b/src/main/kotlin/org/example/root_be/domain/user/domain/repository/UserRepository.kt
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserRepository : JpaRepository<User, Long> {
     fun findByDsmId(dsmId: String): User?
+    fun findAllByIdIn(ids: List<Long>): List<User>
 }

--- a/src/main/kotlin/org/example/root_be/domain/user/facade/UserFacade.kt
+++ b/src/main/kotlin/org/example/root_be/domain/user/facade/UserFacade.kt
@@ -14,6 +14,10 @@ class UserFacade(
         userRepository.findById(id)
             .orElseThrow { throw UserNotFoundException() }
 
+    fun getUsersByIds(userIds: List<Long>): List<User> =
+        userRepository.findAllByIdIn(userIds)
+            .ifEmpty { throw UserNotFoundException() }
+
     fun getCurrentUser(): User {
         val id = SecurityContextHolder.getContext().authentication.name
         return getUserById(id.toLong())

--- a/src/main/kotlin/org/example/root_be/domain/user/presentation/UserController.kt
+++ b/src/main/kotlin/org/example/root_be/domain/user/presentation/UserController.kt
@@ -1,15 +1,16 @@
 package org.example.root_be.domain.user.presentation
 
+import jakarta.validation.Valid
+import org.example.root_be.domain.user.presentation.dto.request.AddStudentVolunteerRecordRequest
 import org.example.root_be.domain.user.presentation.dto.response.MyVolunteerActivityResponse
 import org.example.root_be.domain.user.presentation.dto.response.MypageResponse
 import org.example.root_be.domain.user.presentation.dto.response.StudentQueryResponse
 import org.example.root_be.domain.user.presentation.dto.response.StudentVolunteerActivityResponse
-import org.example.root_be.domain.user.service.MyVolunteerActivityService
-import org.example.root_be.domain.user.service.MypageService
-import org.example.root_be.domain.user.service.StudentQueryService
-import org.example.root_be.domain.user.service.StudentVolunteerActivityService
+import org.example.root_be.domain.user.service.*
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -19,8 +20,9 @@ class UserController(
     private val mypageService: MypageService,
     private val myVolunteerActivityService: MyVolunteerActivityService,
     private val studentQueryService: StudentQueryService,
-    private val studentVolunteerActivityService: StudentVolunteerActivityService
-){
+    private val studentVolunteerActivityService: StudentVolunteerActivityService,
+    private val addStudentVolunteerRecordService: AddStudentVolunteerRecordService
+) {
     @GetMapping("/me")
     fun mypage(): MypageResponse = mypageService.execute()
 
@@ -34,4 +36,9 @@ class UserController(
     fun studentVolunteerActivity(
         @PathVariable userId: Long
     ): StudentVolunteerActivityResponse = studentVolunteerActivityService.execute(userId)
+
+    @PostMapping("/volunteer")
+    fun addStudentVolunteerRecord(
+        @Valid @RequestBody request: AddStudentVolunteerRecordRequest
+    ) = addStudentVolunteerRecordService.execute(request)
 }

--- a/src/main/kotlin/org/example/root_be/domain/user/presentation/dto/request/AddStudentVolunteerRecordRequest.kt
+++ b/src/main/kotlin/org/example/root_be/domain/user/presentation/dto/request/AddStudentVolunteerRecordRequest.kt
@@ -1,0 +1,21 @@
+package org.example.root_be.domain.user.presentation.dto.request
+
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import org.jetbrains.annotations.NotNull
+
+data class AddStudentVolunteerRecordRequest(
+    @NotEmpty(message = "사용자 ID 목록은 필수입니다")
+    val userIds: List<Long>,
+
+    @NotBlank(message = "활동 상세내용은 필수입니다")
+    val detail: String,
+
+    @NotNull
+    @Min(value = 1, message = "봉사시간은 1시간 이상이어야 합니다")
+    val time: Int,
+
+    @NotBlank(message = "봉사장소는 필수입니다")
+    val place: String
+)

--- a/src/main/kotlin/org/example/root_be/domain/user/service/AddStudentVolunteerRecordService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/user/service/AddStudentVolunteerRecordService.kt
@@ -1,0 +1,39 @@
+package org.example.root_be.domain.user.service
+
+import jakarta.transaction.Transactional
+import org.example.root_be.domain.activity.domain.VolunteerActivity
+import org.example.root_be.domain.activity.domain.repository.VolunteerActivityRepository
+import org.example.root_be.domain.detail.domain.VolunteerDetail
+import org.example.root_be.domain.detail.domain.repository.VolunteerDetailRepository
+import org.example.root_be.domain.user.facade.UserFacade
+import org.example.root_be.domain.user.presentation.dto.request.AddStudentVolunteerRecordRequest
+import org.springframework.stereotype.Service
+
+@Service
+class AddStudentVolunteerRecordService(
+    private val volunteerActivityRepository: VolunteerActivityRepository,
+    private val userFacade: UserFacade,
+    private val volunteerDetailRepository: VolunteerDetailRepository
+) {
+    @Transactional
+    fun execute(request: AddStudentVolunteerRecordRequest) {
+        val students = userFacade.getUsersByIds(request.userIds)
+
+        val volunteerDetail = VolunteerDetail(
+            activityDetails = request.detail,
+            place = request.place,
+            time = request.time.toString()
+        )
+        val savedDetail = volunteerDetailRepository.save(volunteerDetail)
+
+        val activities = students.map { student ->
+            VolunteerActivity(
+                user = student,
+                volunteerDetail = savedDetail,
+            )
+        }
+
+        volunteerActivityRepository.saveAll(activities)
+        students.forEach { it.addVolunteerTime(request.time) }
+    }
+}

--- a/src/main/kotlin/org/example/root_be/domain/user/service/MyVolunteerActivityService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/user/service/MyVolunteerActivityService.kt
@@ -18,8 +18,8 @@ class MyVolunteerActivityService(
         val volunteerList = volunteerActivityRepository.findAllByUserId(user.id)
             .map { activity ->
                 VolunteerElement(
-                    volunteerTime = activity.volunteerPost.time,
-                    volunteerAct = activity.volunteerPost.activityDetails
+                    volunteerTime = activity.volunteerDetail.time,
+                    volunteerAct = activity.volunteerDetail.activityDetails
                 )
             }
 

--- a/src/main/kotlin/org/example/root_be/domain/user/service/StudentVolunteerActivityService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/user/service/StudentVolunteerActivityService.kt
@@ -15,8 +15,8 @@ class StudentVolunteerActivityService(
         val volunteerList = volunteerActivityRepository.findAllByUserId(userId)
             .map { activity ->
                 VolunteerElement(
-                    volunteerTime = activity.volunteerPost.time,
-                    volunteerAct = activity.volunteerPost.activityDetails
+                    volunteerTime = activity.volunteerDetail.time,
+                    volunteerAct = activity.volunteerDetail.activityDetails
                 )
             }
 


### PR DESCRIPTION
## #️연관된 이슈

#39 

## 작업 내용

학생 봉사활동 기록을 추가하는 API를 구현한다.
- `VolunteerDetail` 엔티티를 생성하여 봉사활동의 상세 정보를 저장
- `VolunteerActivity` 엔티티에 `volunteerDetail` 필드를 추가하여 봉사활동과 상세 정보를 연결
- `User` 엔티티에 `addVolunteerTime` 메서드를 추가하여 봉사 시간을 업데이트
- `AddStudentVolunteerRecordService`를 구현하여 봉사활동 기록 추가 기능 제공
- 관련된 Repository, Facade, Controller, DTO 추가
- 기존 봉사활동 조회 API에서 `VolunteerPost` 대신 `VolunteerDetail` 엔티티를 사용하도록 수정

