### PR TITLE
merge: 봉사 게시물 수정 기능 개발

### DIFF
--- a/src/main/kotlin/org/example/root_be/domain/post/domain/VolunteerPost.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/domain/VolunteerPost.kt
@@ -1,6 +1,7 @@
 package org.example.root_be.domain.post.domain
 
 import jakarta.persistence.*
+import org.example.root_be.domain.post.presentation.dto.request.ModifyVolunteerPostRequest
 import org.example.root_be.domain.role.domain.VolunteerRole
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -54,4 +55,32 @@ class VolunteerPost(
 
     @OneToMany(mappedBy = "volunteerPost")
     val roles: List<VolunteerRole> = listOf()
-)
+) {
+    fun modifyPost(
+        isRegular: Boolean,
+        title: String,
+        activityDetails: String?,
+        applicationStartDate: LocalDate,
+        applicationEndDate: LocalDate,
+        workStartDate: LocalDate?,
+        workEndDate: LocalDate?,
+        dayOfWeek: String?,
+        place: String,
+        time: String,
+        personnel: String,
+        updatedAt: LocalDateTime
+    ) {
+        this.isRegular = isRegular
+        this.title = title
+        this.activityDetails = activityDetails
+        this.applicationStartDate = applicationStartDate
+        this.applicationEndDate = applicationEndDate
+        this.workStartDate = workStartDate
+        this.workEndDate = workEndDate
+        this.dayOfWeek = dayOfWeek
+        this.place = place
+        this.time = time
+        this.personnel = personnel
+        this.updatedAt = LocalDateTime.now()
+    }
+}

--- a/src/main/kotlin/org/example/root_be/domain/post/presentation/VolunteerController.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/presentation/VolunteerController.kt
@@ -1,12 +1,15 @@
 package org.example.root_be.domain.post.presentation
 
 import org.example.root_be.domain.post.presentation.dto.request.GenerateVolunteerPostRequest
+import org.example.root_be.domain.post.presentation.dto.request.ModifyVolunteerPostRequest
 import org.example.root_be.domain.post.presentation.dto.response.GetVolunteerPostResponse
 import org.example.root_be.domain.post.presentation.dto.response.GetVolunteerPostsResponse
 import org.example.root_be.domain.post.service.GenerateVolunteerPostService
 import org.example.root_be.domain.post.service.GetVolunteerPostDetailsService
 import org.example.root_be.domain.post.service.GetVolunteerPostListService
+import org.example.root_be.domain.post.service.ModifyVolunteerPostService
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -18,7 +21,8 @@ import org.springframework.web.bind.annotation.RestController
 class VolunteerController(
     private val generateVolunteerPostService: GenerateVolunteerPostService,
     private val getVolunteerPostsService: GetVolunteerPostListService,
-    private val getVolunteerPostService: GetVolunteerPostDetailsService
+    private val getVolunteerPostService: GetVolunteerPostDetailsService,
+    private val modifyVolunteerPostService: ModifyVolunteerPostService
 ) {
     @PostMapping
     fun generateVolunteerPost(
@@ -35,5 +39,13 @@ class VolunteerController(
     @GetMapping("/{postId}")
     fun getVolunteerPost(@PathVariable postId: Long): GetVolunteerPostResponse {
         return getVolunteerPostService.execute(postId)
+    }
+
+    @PatchMapping("/{postId}")
+    fun modifyVolunteerPost(
+        @PathVariable postId: Long,
+        @RequestBody request: ModifyVolunteerPostRequest
+    ) {
+        modifyVolunteerPostService.execute(postId, request)
     }
 }

--- a/src/main/kotlin/org/example/root_be/domain/post/presentation/dto/request/ModifyVolunteerPostRequest.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/presentation/dto/request/ModifyVolunteerPostRequest.kt
@@ -1,0 +1,58 @@
+package org.example.root_be.domain.post.presentation.dto.request
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import jakarta.validation.constraints.NotBlank
+import org.hibernate.validator.constraints.Length
+import org.jetbrains.annotations.NotNull
+import java.time.LocalDate
+
+data class ModifyVolunteerPostRequest(
+    @field:NotNull
+    val isRegular: Boolean,
+
+    @field:NotBlank(message = "제목을 비워둘 수 없습니다.")
+    @field:Length(min = 1, max = 30, message = "제목은 최소 1글자, 최대 30글자까지 작성 가능합니다.")
+    val title: String,
+
+    @field:NotBlank(message = "설명을 비워둘 수 없습니다.")
+    @field:Length(min = 1, max = 150, message = "설명은 최소 1글자, 최대 150글자까지 작성 가능합니다.")
+    val activityDetails: String,
+
+    @field:NotNull
+    val applicationPeriod: List<ApplicationPeriodElement>,
+
+    val workDate: List<WorkDateElement>?,
+
+    val dayOfWeek: String?,
+
+    @field:NotNull
+    val place: String,
+
+    @field:NotNull
+    val time: String,
+
+    @field:NotNull
+    val personnel: String,
+
+    @field:NotNull
+    val role: List<RoleElement>
+) {
+    data class ApplicationPeriodElement(
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        val startDate: LocalDate,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        val endDate: LocalDate
+    )
+
+    data class WorkDateElement(
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        val startDate: LocalDate,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        val endDate: LocalDate
+    )
+
+    data class RoleElement(
+        val id: Long,
+        val title: String
+    )
+}

--- a/src/main/kotlin/org/example/root_be/domain/post/presentation/dto/request/ModifyVolunteerPostRequest.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/presentation/dto/request/ModifyVolunteerPostRequest.kt
@@ -52,7 +52,7 @@ data class ModifyVolunteerPostRequest(
     )
 
     data class RoleElement(
-        val id: Long,
+        val roleId: Long?,
         val title: String
     )
 }

--- a/src/main/kotlin/org/example/root_be/domain/post/service/ModifyVolunteerPostService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/service/ModifyVolunteerPostService.kt
@@ -1,0 +1,63 @@
+package org.example.root_be.domain.post.service
+
+import jakarta.transaction.Transactional
+import org.example.root_be.domain.post.domain.VolunteerPost
+import org.example.root_be.domain.post.domain.repository.VolunteerPostRepository
+import org.example.root_be.domain.post.facade.VolunteerFacade
+import org.example.root_be.domain.post.presentation.dto.request.ModifyVolunteerPostRequest
+import org.example.root_be.domain.role.domain.VolunteerRole
+import org.example.root_be.domain.role.domain.repository.RoleRepository
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class ModifyVolunteerPostService(
+    private val volunteerPostRepository: VolunteerPostRepository,
+    private val volunteerFacade: VolunteerFacade,
+    private val roleRepository: RoleRepository,
+) {
+    @Transactional
+    fun execute(
+        postId: Long,
+        request: ModifyVolunteerPostRequest
+    ) {
+        val post = volunteerFacade.getVolunteerPostById(postId)
+
+        val applicationDate = request.applicationPeriod.first()
+        val workDate = request.workDate?.firstOrNull()
+
+        post.modifyPost(
+            isRegular = request.isRegular,
+            title = request.title,
+            activityDetails = request.activityDetails,
+            applicationStartDate = applicationDate.startDate,
+            applicationEndDate = applicationDate.endDate,
+            workStartDate = workDate?.startDate,
+            workEndDate = workDate?.endDate,
+            dayOfWeek = request.dayOfWeek,
+            place = request.place,
+            time = request.time,
+            personnel = request.personnel,
+            updatedAt = LocalDateTime.now()
+        )
+        saveRoles(request, post)
+        volunteerPostRepository.save(post)
+    }
+
+    @Transactional
+    fun saveRoles(
+        request: ModifyVolunteerPostRequest,
+        post: VolunteerPost
+    ) {
+        roleRepository.deleteAllByVolunteerPost(post)
+
+        val roles = request.role.map { role ->
+            VolunteerRole(
+                id = role.id,
+                title = role.title,
+                volunteerPost = post
+            )
+        }
+        roles.forEach { roleRepository.save(it) }
+    }
+}

--- a/src/main/kotlin/org/example/root_be/domain/post/service/ModifyVolunteerPostService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/service/ModifyVolunteerPostService.kt
@@ -7,6 +7,7 @@ import org.example.root_be.domain.post.facade.VolunteerFacade
 import org.example.root_be.domain.post.presentation.dto.request.ModifyVolunteerPostRequest
 import org.example.root_be.domain.role.domain.VolunteerRole
 import org.example.root_be.domain.role.domain.repository.RoleRepository
+import org.example.root_be.domain.role.exception.VolunteerRoleNotFoundException
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 
@@ -40,6 +41,7 @@ class ModifyVolunteerPostService(
             personnel = request.personnel,
             updatedAt = LocalDateTime.now()
         )
+
         saveRoles(request, post)
         volunteerPostRepository.save(post)
     }
@@ -49,15 +51,34 @@ class ModifyVolunteerPostService(
         request: ModifyVolunteerPostRequest,
         post: VolunteerPost
     ) {
-        roleRepository.deleteAllByVolunteerPost(post)
+        val requestedRoleIds = request.role
+            .mapNotNull { it.roleId }
+            .toSet()
 
-        val roles = request.role.map { role ->
-            VolunteerRole(
-                id = role.id,
-                title = role.title,
-                volunteerPost = post
-            )
+        val existingRoles = roleRepository.findAllByVolunteerPost(post)
+
+        val rolesToDelete = existingRoles.filter { it.id !in requestedRoleIds }
+        roleRepository.deleteAll(rolesToDelete)
+
+        val newRoles = mutableListOf<VolunteerRole>()
+
+        request.role.forEach { roleRequest ->
+            when (val id = roleRequest.roleId) {
+                null -> newRoles.add(
+                    VolunteerRole(
+                        id = 0,
+                        title = roleRequest.title,
+                        volunteerPost = post
+                    )
+                )
+                else -> existingRoles.find { it.id == id }
+                    ?.apply { title = roleRequest.title }
+                    ?: throw VolunteerRoleNotFoundException
+            }
         }
-        roles.forEach { roleRepository.save(it) }
+
+        if (newRoles.isNotEmpty()) {
+            roleRepository.saveAll(newRoles)
+        }
     }
 }

--- a/src/main/kotlin/org/example/root_be/domain/role/domain/VolunteerRole.kt
+++ b/src/main/kotlin/org/example/root_be/domain/role/domain/VolunteerRole.kt
@@ -16,4 +16,10 @@ class VolunteerRole(
 
     @Column(name = "title")
     var title: String,
-)
+) {
+    fun modifyRole(
+        title: String
+    ) {
+        this.title = title
+    }
+}

--- a/src/main/kotlin/org/example/root_be/domain/role/domain/VolunteerRole.kt
+++ b/src/main/kotlin/org/example/root_be/domain/role/domain/VolunteerRole.kt
@@ -8,7 +8,7 @@ import org.example.root_be.domain.post.domain.VolunteerPost
 class VolunteerRole(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long,
+    val id: Long = 0L,
 
     @ManyToOne
     @JoinColumn(name = "post_id")

--- a/src/main/kotlin/org/example/root_be/domain/role/domain/VolunteerRole.kt
+++ b/src/main/kotlin/org/example/root_be/domain/role/domain/VolunteerRole.kt
@@ -16,10 +16,4 @@ class VolunteerRole(
 
     @Column(name = "title")
     var title: String,
-) {
-    fun modifyRole(
-        title: String
-    ) {
-        this.title = title
-    }
-}
+)

--- a/src/main/kotlin/org/example/root_be/domain/role/domain/repository/RoleRepository.kt
+++ b/src/main/kotlin/org/example/root_be/domain/role/domain/repository/RoleRepository.kt
@@ -5,6 +5,5 @@ import org.example.root_be.domain.role.domain.VolunteerRole
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface RoleRepository: JpaRepository<VolunteerRole, Long> {
-    fun deleteAllByVolunteerPost(post: VolunteerPost)
     fun findAllByVolunteerPost(post: VolunteerPost): List<VolunteerRole>
 }

--- a/src/main/kotlin/org/example/root_be/domain/role/domain/repository/RoleRepository.kt
+++ b/src/main/kotlin/org/example/root_be/domain/role/domain/repository/RoleRepository.kt
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface RoleRepository: JpaRepository<VolunteerRole, Long> {
     fun deleteAllByVolunteerPost(post: VolunteerPost)
+    fun findAllByVolunteerPost(post: VolunteerPost): List<VolunteerRole>
 }

--- a/src/main/kotlin/org/example/root_be/domain/role/domain/repository/RoleRepository.kt
+++ b/src/main/kotlin/org/example/root_be/domain/role/domain/repository/RoleRepository.kt
@@ -1,6 +1,9 @@
 package org.example.root_be.domain.role.domain.repository
 
+import org.example.root_be.domain.post.domain.VolunteerPost
 import org.example.root_be.domain.role.domain.VolunteerRole
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface RoleRepository: JpaRepository<VolunteerRole, Long>
+interface RoleRepository: JpaRepository<VolunteerRole, Long> {
+    fun findAllByVolunteerPostId(postId: Long): List<VolunteerRole>
+}

--- a/src/main/kotlin/org/example/root_be/domain/role/domain/repository/RoleRepository.kt
+++ b/src/main/kotlin/org/example/root_be/domain/role/domain/repository/RoleRepository.kt
@@ -5,5 +5,5 @@ import org.example.root_be.domain.role.domain.VolunteerRole
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface RoleRepository: JpaRepository<VolunteerRole, Long> {
-    fun findAllByVolunteerPostId(postId: Long): List<VolunteerRole>
+    fun deleteAllByVolunteerPost(post: VolunteerPost)
 }

--- a/src/main/kotlin/org/example/root_be/domain/role/exception/VolunteerRoleNotFoundException.kt
+++ b/src/main/kotlin/org/example/root_be/domain/role/exception/VolunteerRoleNotFoundException.kt
@@ -1,0 +1,6 @@
+package org.example.root_be.domain.role.exception
+
+import org.example.root_be.global.err.exception.CustomException
+import org.example.root_be.global.err.exception.ErrorCode
+
+object VolunteerRoleNotFoundException: CustomException(ErrorCode.VOLUNTEER_ROLE_NOT_FOUND)

--- a/src/main/kotlin/org/example/root_be/global/err/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/example/root_be/global/err/exception/ErrorCode.kt
@@ -8,6 +8,7 @@ enum class ErrorCode(
     INVALID_TOKEN("Invalid Token", 401),
     EXPIRED_TOKEN("Expired Token", 401),
     VOLUNTEER_POST_NOT_FOUND("Post Not Found", 404),
+    VOLUNTEER_ROLE_NOT_FOUND("Role Not Found", 404),
     USER_NOT_FOUND("User Not Found", 404),
     INVALID_PASSWORD("Invalid Password", 401),
     FEIGN_BAD_REQUEST("External API request is invalid.", 400),


### PR DESCRIPTION
## #️연관된 이슈

> #30

## 작업 내용

> 봉사 게시물 수정 API를 개발하였습니다.
> `ModifyVolunteerPostRequest`추가. 
> `RoleRepository`에 `deleteAllByVolunteerPost` 메서드 추가,.
> `ModifyVolunteerPostService` 추가.
> `VolunteerController`에 `modifyVolunteerPost` 추가.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/d0f13af7-631d-4638-8feb-74d35c4cf199)


## 리뷰 요구사항(선택)

> `ModifyVolunteerPostService`에 `saveRoles` 메서드 로직을 중심적으로 봐주셨으면 좋겠습니다.