### PR TITLE
merge: VolunteerPost 엔티티 관련 로직 리팩토링

### DIFF
--- a/src/main/kotlin/org/example/root_be/domain/detail/domain/VolunteerDetail.kt
+++ b/src/main/kotlin/org/example/root_be/domain/detail/domain/VolunteerDetail.kt
@@ -25,4 +25,14 @@ class VolunteerDetail(
 
     @OneToMany(mappedBy = "volunteerDetail")
     val volunteerActivities: List<VolunteerActivity> = mutableListOf()
-)
+) {
+    fun modifyDetail(
+        activityDetails: String,
+        place: String,
+        time: String
+    ) {
+        this.activityDetails = activityDetails
+        this.place = place
+        this.time = time
+    }
+}

--- a/src/main/kotlin/org/example/root_be/domain/detail/domain/VolunteerDetail.kt
+++ b/src/main/kotlin/org/example/root_be/domain/detail/domain/VolunteerDetail.kt
@@ -12,13 +12,13 @@ class VolunteerDetail(
     val id: Long = 0,
 
     @Column(nullable = false)
-    val activityDetails: String,
+    var activityDetails: String,
 
     @Column(nullable = false)
-    val place: String,
+    var place: String,
 
     @Column(nullable = false)
-    val time: String,
+    var time: String,
 
     @OneToOne(mappedBy = "volunteerDetail")
     val volunteerPost: VolunteerPost? = null,

--- a/src/main/kotlin/org/example/root_be/domain/detail/exception/VolunteerDetailNotFoundException.kt
+++ b/src/main/kotlin/org/example/root_be/domain/detail/exception/VolunteerDetailNotFoundException.kt
@@ -1,0 +1,6 @@
+package org.example.root_be.domain.detail.exception
+
+import org.example.root_be.global.err.exception.CustomException
+import org.example.root_be.global.err.exception.ErrorCode
+
+object VolunteerDetailNotFoundException: CustomException(ErrorCode.VOLUNTEER_DETAIL_NOT_FOUND)

--- a/src/main/kotlin/org/example/root_be/domain/detail/facade/DetailFacade.kt
+++ b/src/main/kotlin/org/example/root_be/domain/detail/facade/DetailFacade.kt
@@ -1,0 +1,18 @@
+package org.example.root_be.domain.detail.facade
+
+import org.example.root_be.domain.detail.domain.VolunteerDetail
+import org.example.root_be.domain.detail.domain.repository.VolunteerDetailRepository
+import org.example.root_be.domain.detail.exception.VolunteerDetailNotFoundException
+import org.springframework.stereotype.Component
+
+@Component
+class DetailFacade(
+    private val volunteerDetailRepository: VolunteerDetailRepository
+) {
+    fun getVolunteerDetailsByPostId(
+        postId: Long
+    ): VolunteerDetail {
+        return volunteerDetailRepository.findById(postId)
+            .orElseThrow { VolunteerDetailNotFoundException }
+    }
+}

--- a/src/main/kotlin/org/example/root_be/domain/post/domain/VolunteerPost.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/domain/VolunteerPost.kt
@@ -39,12 +39,6 @@ class VolunteerPost(
     @Column(name = "is_regular", nullable = false)
     var isRegular: Boolean,
 
-    @Column(name = "place", nullable = false)
-    var place: String,
-
-    @Column(name = "time", nullable = false)
-    var time: String,
-
     @Column(name = "personnel", nullable = false)
     var personnel: String,
 
@@ -66,8 +60,6 @@ class VolunteerPost(
         workStartDate: LocalDate?,
         workEndDate: LocalDate?,
         dayOfWeek: String?,
-        place: String,
-        time: String,
         personnel: String,
         updatedAt: LocalDateTime
     ) {
@@ -79,8 +71,6 @@ class VolunteerPost(
         this.workStartDate = workStartDate
         this.workEndDate = workEndDate
         this.dayOfWeek = dayOfWeek
-        this.place = place
-        this.time = time
         this.personnel = personnel
         this.updatedAt = LocalDateTime.now()
     }

--- a/src/main/kotlin/org/example/root_be/domain/post/domain/VolunteerPost.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/domain/VolunteerPost.kt
@@ -1,7 +1,7 @@
 package org.example.root_be.domain.post.domain
 
 import jakarta.persistence.*
-import org.example.root_be.domain.post.presentation.dto.request.ModifyVolunteerPostRequest
+import org.example.root_be.domain.detail.domain.VolunteerDetail
 import org.example.root_be.domain.role.domain.VolunteerRole
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -17,8 +17,9 @@ class VolunteerPost(
     @Column(name = "title", nullable = false)
     var title: String,
 
-    @Column(name = "activity_details")
-    var activityDetails: String?,
+    @OneToOne
+    @JoinColumn(name = "detail_id")
+    var volunteerDetail: VolunteerDetail,
 
     @Column(name = "application_start_date", nullable = false)
     var applicationStartDate: LocalDate,
@@ -48,7 +49,7 @@ class VolunteerPost(
     var personnel: String,
 
     @Column(name = "created_at", nullable = false)
-    val createAt: LocalDateTime = LocalDateTime.now(),
+    val createdAt: LocalDateTime = LocalDateTime.now(),
 
     @Column(name = "updated_at")
     var updatedAt: LocalDateTime = LocalDateTime.now(),
@@ -59,7 +60,7 @@ class VolunteerPost(
     fun modifyPost(
         isRegular: Boolean,
         title: String,
-        activityDetails: String?,
+        volunteerDetail: VolunteerDetail,
         applicationStartDate: LocalDate,
         applicationEndDate: LocalDate,
         workStartDate: LocalDate?,
@@ -72,7 +73,7 @@ class VolunteerPost(
     ) {
         this.isRegular = isRegular
         this.title = title
-        this.activityDetails = activityDetails
+        this.volunteerDetail = volunteerDetail
         this.applicationStartDate = applicationStartDate
         this.applicationEndDate = applicationEndDate
         this.workStartDate = workStartDate

--- a/src/main/kotlin/org/example/root_be/domain/post/domain/VolunteerPost.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/domain/VolunteerPost.kt
@@ -54,7 +54,6 @@ class VolunteerPost(
     fun modifyPost(
         isRegular: Boolean,
         title: String,
-        volunteerDetail: VolunteerDetail,
         applicationStartDate: LocalDate,
         applicationEndDate: LocalDate,
         workStartDate: LocalDate?,
@@ -65,7 +64,6 @@ class VolunteerPost(
     ) {
         this.isRegular = isRegular
         this.title = title
-        this.volunteerDetail = volunteerDetail
         this.applicationStartDate = applicationStartDate
         this.applicationEndDate = applicationEndDate
         this.workStartDate = workStartDate

--- a/src/main/kotlin/org/example/root_be/domain/post/domain/VolunteerPost.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/domain/VolunteerPost.kt
@@ -19,7 +19,7 @@ class VolunteerPost(
 
     @OneToOne
     @JoinColumn(name = "detail_id")
-    var volunteerDetail: VolunteerDetail,
+    var volunteerDetail: VolunteerDetail? = null,
 
     @Column(name = "application_start_date", nullable = false)
     var applicationStartDate: LocalDate,

--- a/src/main/kotlin/org/example/root_be/domain/post/presentation/dto/response/GetVolunteerPostResponse.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/presentation/dto/response/GetVolunteerPostResponse.kt
@@ -1,6 +1,7 @@
 package org.example.root_be.domain.post.presentation.dto.response
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import org.example.root_be.domain.detail.domain.VolunteerDetail
 import org.example.root_be.domain.post.domain.VolunteerPost
 import java.time.LocalDate
 
@@ -16,15 +17,18 @@ data class GetVolunteerPostResponse(
     val personnel: String,
     val role: List<RoleResponse>
 ) {
-    constructor(volunteerPost: VolunteerPost): this(
+    constructor(
+        volunteerPost: VolunteerPost,
+        volunteerDetail: VolunteerDetail
+    ): this(
         id = volunteerPost.id,
         title = volunteerPost.title,
-        activityDetails = volunteerPost.activityDetails,
+        activityDetails = volunteerDetail.activityDetails,
         applicationPeriod = listOf(ApplicationPeriodResponse(volunteerPost)),
         workDate = listOf(WorkDateResponse(volunteerPost)),
         dayOfWeek = volunteerPost.dayOfWeek,
-        place = volunteerPost.place,
-        time = volunteerPost.time,
+        place = volunteerDetail.place,
+        time = volunteerDetail.time,
         personnel = volunteerPost.personnel,
         role = volunteerPost.roles.map { RoleResponse(it.id, it.title) }
     )

--- a/src/main/kotlin/org/example/root_be/domain/post/service/GenerateVolunteerPostService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/service/GenerateVolunteerPostService.kt
@@ -24,21 +24,11 @@ class GenerateVolunteerPostService(
         val applicationDate = request.applicationPeriod.first()
         val workDate = request.workDate?.firstOrNull()
 
-        val detail =
-            request.run {
-                VolunteerDetail(
-                    activityDetails = activityDetails,
-                    place = place,
-                    time = time
-                )
-            }
-
         val volunteerPost =
             request.run {
                 VolunteerPost(
                     isRegular = isRegular,
                     title = title,
-                    volunteerDetail = detail,
                     applicationStartDate = applicationDate.startDate,
                     applicationEndDate = applicationDate.endDate,
                     workStartDate = workDate?.startDate,
@@ -49,9 +39,26 @@ class GenerateVolunteerPostService(
                 )
             }
 
-        volunteerDetailRepository.save(detail)
-        volunteerPostRepository.save(volunteerPost)
+        saveDetail(volunteerPost, request)
         saveRoles(request, volunteerPost)
+        volunteerPostRepository.save(volunteerPost)
+    }
+
+    @Transactional
+    fun saveDetail(
+        volunteerPost: VolunteerPost,
+        request: GenerateVolunteerPostRequest
+    ) {
+        val detail =
+            request.run {
+                VolunteerDetail(
+                    activityDetails = activityDetails,
+                    place = place,
+                    time = time,
+                    volunteerPost = volunteerPost
+                )
+            }
+        volunteerDetailRepository.save(detail)
     }
 
     @Transactional

--- a/src/main/kotlin/org/example/root_be/domain/post/service/GenerateVolunteerPostService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/service/GenerateVolunteerPostService.kt
@@ -1,6 +1,8 @@
 package org.example.root_be.domain.post.service
 
 import jakarta.transaction.Transactional
+import org.example.root_be.domain.detail.domain.VolunteerDetail
+import org.example.root_be.domain.detail.domain.repository.VolunteerDetailRepository
 import org.example.root_be.domain.role.domain.VolunteerRole
 import org.example.root_be.domain.role.domain.repository.RoleRepository
 import org.example.root_be.domain.post.domain.VolunteerPost
@@ -12,7 +14,8 @@ import java.time.LocalDateTime
 @Service
 class GenerateVolunteerPostService(
     private val volunteerPostRepository: VolunteerPostRepository,
-    private val roleRepository: RoleRepository
+    private val roleRepository: RoleRepository,
+    private val volunteerDetailRepository: VolunteerDetailRepository
 ) {
     @Transactional
     fun execute(
@@ -21,24 +24,32 @@ class GenerateVolunteerPostService(
         val applicationDate = request.applicationPeriod.first()
         val workDate = request.workDate?.firstOrNull()
 
+        val detail =
+            request.run {
+                VolunteerDetail(
+                    activityDetails = activityDetails,
+                    place = place,
+                    time = time
+                )
+            }
+
         val volunteerPost =
             request.run {
                 VolunteerPost(
                     isRegular = isRegular,
                     title = title,
-                    activityDetails = activityDetails,
+                    volunteerDetail = detail,
                     applicationStartDate = applicationDate.startDate,
                     applicationEndDate = applicationDate.endDate,
                     workStartDate = workDate?.startDate,
                     workEndDate = workDate?.endDate,
                     dayOfWeek = dayOfWeek,
-                    place = place,
-                    time = time,
                     personnel = personnel,
-                    createAt = LocalDateTime.now(),
+                    createdAt = LocalDateTime.now(),
                 )
             }
 
+        volunteerDetailRepository.save(detail)
         volunteerPostRepository.save(volunteerPost)
         saveRoles(request, volunteerPost)
     }

--- a/src/main/kotlin/org/example/root_be/domain/post/service/GetVolunteerPostDetailsService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/service/GetVolunteerPostDetailsService.kt
@@ -1,19 +1,22 @@
 package org.example.root_be.domain.post.service
 
 import jakarta.transaction.Transactional
+import org.example.root_be.domain.detail.facade.DetailFacade
 import org.example.root_be.domain.post.facade.VolunteerFacade
 import org.example.root_be.domain.post.presentation.dto.response.GetVolunteerPostResponse
 import org.springframework.stereotype.Service
 
 @Service
 class GetVolunteerPostDetailsService(
-    private val volunteerFacade: VolunteerFacade
+    private val volunteerFacade: VolunteerFacade,
+    private val detailsFacade: DetailFacade
 ) {
     @Transactional
     fun execute(
         postId: Long
     ): GetVolunteerPostResponse {
         val volunteerPost = volunteerFacade.getVolunteerPostById(postId)
-        return GetVolunteerPostResponse(volunteerPost)
+        val volunteerDetail = detailsFacade.getVolunteerDetailsByPostId(postId)
+        return GetVolunteerPostResponse(volunteerPost, volunteerDetail)
     }
 }

--- a/src/main/kotlin/org/example/root_be/domain/post/service/ModifyVolunteerPostService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/service/ModifyVolunteerPostService.kt
@@ -1,6 +1,8 @@
 package org.example.root_be.domain.post.service
 
 import jakarta.transaction.Transactional
+import org.example.root_be.domain.detail.domain.repository.VolunteerDetailRepository
+import org.example.root_be.domain.detail.facade.DetailFacade
 import org.example.root_be.domain.post.domain.VolunteerPost
 import org.example.root_be.domain.post.domain.repository.VolunteerPostRepository
 import org.example.root_be.domain.post.facade.VolunteerFacade
@@ -16,6 +18,8 @@ class ModifyVolunteerPostService(
     private val volunteerPostRepository: VolunteerPostRepository,
     private val volunteerFacade: VolunteerFacade,
     private val roleRepository: RoleRepository,
+    private val detailFacade: DetailFacade,
+    private val volunteerDetailRepository: VolunteerDetailRepository
 ) {
     @Transactional
     fun execute(
@@ -30,20 +34,34 @@ class ModifyVolunteerPostService(
         post.modifyPost(
             isRegular = request.isRegular,
             title = request.title,
-            activityDetails = request.activityDetails,
             applicationStartDate = applicationDate.startDate,
             applicationEndDate = applicationDate.endDate,
             workStartDate = workDate?.startDate,
             workEndDate = workDate?.endDate,
             dayOfWeek = request.dayOfWeek,
-            place = request.place,
-            time = request.time,
             personnel = request.personnel,
             updatedAt = LocalDateTime.now()
         )
 
+        saveDetail(request, post)
         saveRoles(request, post)
         volunteerPostRepository.save(post)
+    }
+
+    @Transactional
+    fun saveDetail(
+        request: ModifyVolunteerPostRequest,
+        post: VolunteerPost
+    ) {
+        val detail = detailFacade.getVolunteerDetailsByPostId(post.id)
+        request.run {
+            detail.modifyDetail(
+                activityDetails = activityDetails,
+                place = place,
+                time = time
+            )
+        }
+        volunteerDetailRepository.save(detail)
     }
 
     @Transactional

--- a/src/main/kotlin/org/example/root_be/global/err/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/example/root_be/global/err/exception/ErrorCode.kt
@@ -9,6 +9,7 @@ enum class ErrorCode(
     EXPIRED_TOKEN("Expired Token", 401),
     VOLUNTEER_POST_NOT_FOUND("Post Not Found", 404),
     VOLUNTEER_ROLE_NOT_FOUND("Role Not Found", 404),
+    VOLUNTEER_DETAIL_NOT_FOUND("Detail Not Found", 404),
     USER_NOT_FOUND("User Not Found", 404),
     INVALID_PASSWORD("Invalid Password", 401),
     FEIGN_BAD_REQUEST("External API request is invalid.", 400),


### PR DESCRIPTION
## #️연관된 이슈

> #45

## 작업 내용

> 다음과 같이 `VolunteerPost` 엔티티를 리팩토링하였습니다.
```
VOLUNTEER_POST {
       Long id PK
       Long detail_id FK
       string title
       datetime application_start_date
       datetime application_end_date
       datetime work_start_date
       datetime work_end_date
       string day_of_week
       string personnel
       boolean is_regular
       datetime created_at
       datetime updated_at
   }
```

> 리팩토링한 `VolunteerPost` 엔티티에 따라 `VolunteerPost` 엔티티와 연관된 `GenerateVolunteerPostService`, `ModifyVolunteerPostService` 로직을 리팩토링하였습니다.
> `DetailsFacade`, `VolunteerDetailNotFoundException`, `ErrorCode`에 `VOLUNTEER_DETAIL_NOT_FOUND`를 추가하였습니다.


