### PR TITLE
feat: (#42) QR 코드 생성 기능 추가

### DIFF
--- a/src/main/kotlin/org/example/root_be/domain/qrcode/domain/QrCode.kt
+++ b/src/main/kotlin/org/example/root_be/domain/qrcode/domain/QrCode.kt
@@ -1,0 +1,32 @@
+package org.example.root_be.domain.qrcode.domain
+import jakarta.persistence.*
+import org.example.root_be.domain.post.domain.VolunteerPost
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "qr_code")
+class QrCode(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(unique = true, nullable = false)
+    val code: Int,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    var volunteerPost: VolunteerPost,
+
+    @Column(nullable = false)
+    val generatedAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(nullable = false)
+    var isUsed: Boolean = false,
+
+    var usedAt: LocalDateTime? = null
+) {
+    fun markAsUsed() {
+        isUsed = true
+        usedAt = LocalDateTime.now()
+    }
+}

--- a/src/main/kotlin/org/example/root_be/domain/qrcode/domain/repository/QrCodeRepository.kt
+++ b/src/main/kotlin/org/example/root_be/domain/qrcode/domain/repository/QrCodeRepository.kt
@@ -1,0 +1,10 @@
+package org.example.root_be.domain.qrcode.domain.repository
+
+import org.example.root_be.domain.qrcode.domain.QrCode
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface QrCodeRepository : JpaRepository<QrCode, Long> {
+    fun existsByCode(code: Int): Boolean
+}

--- a/src/main/kotlin/org/example/root_be/domain/qrcode/presentation/QRCodeController.kt
+++ b/src/main/kotlin/org/example/root_be/domain/qrcode/presentation/QRCodeController.kt
@@ -1,0 +1,20 @@
+package org.example.root_be.domain.qrcode.presentation
+
+import org.example.root_be.domain.qrcode.presentation.dto.request.GenerateQRCodeRequest
+import org.example.root_be.domain.qrcode.presentation.dto.response.GenerateQRCodeResponse
+import org.example.root_be.domain.qrcode.service.GenerateQRCodeService
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/qr")
+class QRCodeController(
+    private val generateQRCodeService: GenerateQRCodeService
+) {
+    @PostMapping
+    fun generateQRCode(
+        @RequestBody request: GenerateQRCodeRequest
+    ): GenerateQRCodeResponse = generateQRCodeService.generate(request)
+}

--- a/src/main/kotlin/org/example/root_be/domain/qrcode/presentation/dto/request/GenerateQRCodeRequest.kt
+++ b/src/main/kotlin/org/example/root_be/domain/qrcode/presentation/dto/request/GenerateQRCodeRequest.kt
@@ -1,0 +1,5 @@
+package org.example.root_be.domain.qrcode.presentation.dto.request
+
+data class GenerateQRCodeRequest(
+    val postId: Long
+)

--- a/src/main/kotlin/org/example/root_be/domain/qrcode/presentation/dto/response/GenerateQRCodeResponse.kt
+++ b/src/main/kotlin/org/example/root_be/domain/qrcode/presentation/dto/response/GenerateQRCodeResponse.kt
@@ -1,0 +1,5 @@
+package org.example.root_be.domain.qrcode.presentation.dto.response
+
+data class GenerateQRCodeResponse(
+    val qrCode: Int
+)

--- a/src/main/kotlin/org/example/root_be/domain/qrcode/service/GenerateQRCodeService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/qrcode/service/GenerateQRCodeService.kt
@@ -1,0 +1,35 @@
+package org.example.root_be.domain.qrcode.service
+
+import org.example.root_be.domain.post.facade.VolunteerFacade
+import org.example.root_be.domain.qrcode.domain.QrCode
+import org.example.root_be.domain.qrcode.domain.repository.QrCodeRepository
+import org.example.root_be.domain.qrcode.presentation.dto.request.GenerateQRCodeRequest
+import org.example.root_be.domain.qrcode.presentation.dto.response.GenerateQRCodeResponse
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import kotlin.random.Random
+
+@Service
+class GenerateQRCodeService(
+    private val qrCodeRepository: QrCodeRepository,
+    private val volunteerFacade: VolunteerFacade
+) {
+    @Transactional
+    fun generate(request: GenerateQRCodeRequest): GenerateQRCodeResponse {
+        val post = volunteerFacade.getVolunteerPostById(request.postId)
+
+        var qrCode: Int
+        do {
+            qrCode = Random.nextInt(100000, 1000000)
+        } while (qrCodeRepository.existsByCode(qrCode))
+
+        qrCodeRepository.save(
+            QrCode(
+                code = qrCode,
+                volunteerPost = post
+            )
+        )
+
+        return GenerateQRCodeResponse(qrCode)
+    }
+}


### PR DESCRIPTION
## #️연관된 이슈

#42 

## 작업 내용

QR 코드 생성 API, 도메인, 레포지토리 추가
- 게시글 id를 통해 QR 코드 생성
- 생성된 QR 코드는 봉사활동 참여 확인에 사용
- QR 코드는 6자리 숫자로 생성
- 중복 방지를 위해 생성된 QR 코드는 DB에 저장

