### PR TITLE
봉사 게시물 삭제 기능 개발

### DIFF
--- a/src/main/kotlin/org/example/root_be/domain/post/domain/VolunteerPost.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/domain/VolunteerPost.kt
@@ -17,9 +17,9 @@ class VolunteerPost(
     @Column(name = "title", nullable = false)
     var title: String,
 
-    @OneToOne
+    @OneToOne(cascade = [CascadeType.ALL])
     @JoinColumn(name = "detail_id")
-    var volunteerDetail: VolunteerDetail? = null,
+    var volunteerDetail: VolunteerDetail,
 
     @Column(name = "application_start_date", nullable = false)
     var applicationStartDate: LocalDate,
@@ -48,7 +48,7 @@ class VolunteerPost(
     @Column(name = "updated_at")
     var updatedAt: LocalDateTime = LocalDateTime.now(),
 
-    @OneToMany(mappedBy = "volunteerPost")
+    @OneToMany(mappedBy = "volunteerPost", cascade = [CascadeType.ALL])
     val roles: List<VolunteerRole> = listOf()
 ) {
     fun modifyPost(

--- a/src/main/kotlin/org/example/root_be/domain/post/presentation/VolunteerController.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/presentation/VolunteerController.kt
@@ -4,10 +4,8 @@ import org.example.root_be.domain.post.presentation.dto.request.GenerateVoluntee
 import org.example.root_be.domain.post.presentation.dto.request.ModifyVolunteerPostRequest
 import org.example.root_be.domain.post.presentation.dto.response.GetVolunteerPostResponse
 import org.example.root_be.domain.post.presentation.dto.response.GetVolunteerPostsResponse
-import org.example.root_be.domain.post.service.GenerateVolunteerPostService
-import org.example.root_be.domain.post.service.GetVolunteerPostDetailsService
-import org.example.root_be.domain.post.service.GetVolunteerPostListService
-import org.example.root_be.domain.post.service.ModifyVolunteerPostService
+import org.example.root_be.domain.post.service.*
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -22,7 +20,8 @@ class VolunteerController(
     private val generateVolunteerPostService: GenerateVolunteerPostService,
     private val getVolunteerPostsService: GetVolunteerPostListService,
     private val getVolunteerPostService: GetVolunteerPostDetailsService,
-    private val modifyVolunteerPostService: ModifyVolunteerPostService
+    private val modifyVolunteerPostService: ModifyVolunteerPostService,
+    private val deleteVolunteerPostService: DeleteVolunteerPostService
 ) {
     @PostMapping
     fun generateVolunteerPost(
@@ -47,5 +46,12 @@ class VolunteerController(
         @RequestBody request: ModifyVolunteerPostRequest
     ) {
         modifyVolunteerPostService.execute(postId, request)
+    }
+
+    @DeleteMapping("/{postId}")
+    fun deleteVolunteerPost(
+        @PathVariable postId: Long
+    ) {
+        deleteVolunteerPostService.execute(postId)
     }
 }

--- a/src/main/kotlin/org/example/root_be/domain/post/service/DeleteVolunteerPostService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/service/DeleteVolunteerPostService.kt
@@ -1,0 +1,20 @@
+package org.example.root_be.domain.post.service
+
+import jakarta.transaction.Transactional
+import org.example.root_be.domain.post.domain.repository.VolunteerPostRepository
+import org.example.root_be.domain.post.facade.VolunteerFacade
+import org.springframework.stereotype.Service
+
+@Service
+class DeleteVolunteerPostService(
+    private val volunteerFacade: VolunteerFacade,
+    private val volunteerPostRepository: VolunteerPostRepository
+) {
+    @Transactional
+    fun execute(
+        postId: Long
+    ) {
+        val post = volunteerFacade.getVolunteerPostById(postId)
+        volunteerPostRepository.delete(post)
+    }
+}

--- a/src/main/kotlin/org/example/root_be/domain/post/service/GenerateVolunteerPostService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/service/GenerateVolunteerPostService.kt
@@ -24,11 +24,21 @@ class GenerateVolunteerPostService(
         val applicationDate = request.applicationPeriod.first()
         val workDate = request.workDate?.firstOrNull()
 
+        val detail =
+            request.run {
+                VolunteerDetail(
+                    activityDetails = activityDetails,
+                    place = place,
+                    time = time,
+                )
+            }
+
         val volunteerPost =
             request.run {
                 VolunteerPost(
                     isRegular = isRegular,
                     title = title,
+                    volunteerDetail = detail,
                     applicationStartDate = applicationDate.startDate,
                     applicationEndDate = applicationDate.endDate,
                     workStartDate = workDate?.startDate,
@@ -39,26 +49,9 @@ class GenerateVolunteerPostService(
                 )
             }
 
-        saveDetail(volunteerPost, request)
         saveRoles(request, volunteerPost)
-        volunteerPostRepository.save(volunteerPost)
-    }
-
-    @Transactional
-    fun saveDetail(
-        volunteerPost: VolunteerPost,
-        request: GenerateVolunteerPostRequest
-    ) {
-        val detail =
-            request.run {
-                VolunteerDetail(
-                    activityDetails = activityDetails,
-                    place = place,
-                    time = time,
-                    volunteerPost = volunteerPost
-                )
-            }
         volunteerDetailRepository.save(detail)
+        volunteerPostRepository.save(volunteerPost)
     }
 
     @Transactional


### PR DESCRIPTION
## #️연관된 이슈

> #47

## 작업 내용

> 봉사 게시물 삭제 API를 개발하였습니다.
    - `VolunteerPost`와 연관관계를 맺은 엔티티들의 `cascade` 설정을 하였습니다.
    
> `GenerateVolunteerPostService`의 게시물 저장 로직을 수정하였습니다.
> `VolunteerController`에 `deleteVolunteerPost` 메서드를 추가하였습니다.