### PR TITLE
봉사 일정 목록 조회 기능 개발

### DIFF
--- a/src/main/kotlin/org/example/root_be/domain/schedule/domain/repository/ScheduleRepository.kt
+++ b/src/main/kotlin/org/example/root_be/domain/schedule/domain/repository/ScheduleRepository.kt
@@ -3,4 +3,6 @@ package org.example.root_be.domain.schedule.domain.repository
 import org.example.root_be.domain.schedule.domain.Schedule
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface ScheduleRepository: JpaRepository<Schedule, Long>
+interface ScheduleRepository: JpaRepository<Schedule, Long> {
+    fun findBy(): List<Schedule>
+}

--- a/src/main/kotlin/org/example/root_be/domain/schedule/presentation/ScheduleController.kt
+++ b/src/main/kotlin/org/example/root_be/domain/schedule/presentation/ScheduleController.kt
@@ -1,7 +1,10 @@
 package org.example.root_be.domain.schedule.presentation
 
 import org.example.root_be.domain.schedule.presentation.dto.request.GenerateScheduleRequest
+import org.example.root_be.domain.schedule.presentation.dto.response.GetScheduleListResponse
 import org.example.root_be.domain.schedule.service.GenerateScheduleService
+import org.example.root_be.domain.schedule.service.GetScheduleListService
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -10,12 +13,18 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/schedules")
 class ScheduleController(
-    private val generateScheduleService: GenerateScheduleService
+    private val generateScheduleService: GenerateScheduleService,
+    private val getScheduleListService: GetScheduleListService
 ) {
     @PostMapping
     fun generateSchedule(
         @RequestBody request: GenerateScheduleRequest
     ) {
         generateScheduleService.execute(request)
+    }
+
+    @GetMapping
+    fun getScheduleList(): GetScheduleListResponse {
+        return getScheduleListService.execute()
     }
 }

--- a/src/main/kotlin/org/example/root_be/domain/schedule/presentation/dto/response/GetScheduleListResponse.kt
+++ b/src/main/kotlin/org/example/root_be/domain/schedule/presentation/dto/response/GetScheduleListResponse.kt
@@ -1,0 +1,22 @@
+package org.example.root_be.domain.schedule.presentation.dto.response
+
+import org.example.root_be.domain.schedule.domain.Schedule
+import java.time.LocalDate
+
+data class GetScheduleListResponse(
+    val events: List<ScheduleElement>
+) {
+    data class ScheduleElement(
+        val title: String,
+        val startDate: LocalDate,
+        val endDate: LocalDate,
+    ) {
+        constructor(
+            schedule: Schedule
+        ): this(
+            schedule.title,
+            schedule.startDate,
+            schedule.endDate
+        )
+    }
+}

--- a/src/main/kotlin/org/example/root_be/domain/schedule/service/GetScheduleListService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/schedule/service/GetScheduleListService.kt
@@ -1,0 +1,19 @@
+package org.example.root_be.domain.schedule.service
+
+import jakarta.transaction.Transactional
+import org.example.root_be.domain.schedule.domain.repository.ScheduleRepository
+import org.example.root_be.domain.schedule.presentation.dto.response.GetScheduleListResponse
+import org.springframework.stereotype.Service
+
+@Service
+class GetScheduleListService(
+    private val scheduleRepository: ScheduleRepository
+) {
+    @Transactional
+    fun execute(): GetScheduleListResponse {
+        return GetScheduleListResponse(
+            scheduleRepository.findBy()
+                .map { GetScheduleListResponse.ScheduleElement(it) }
+        )
+    }
+}


### PR DESCRIPTION
## #️연관된 이슈

> #52

## 작업 내용

> 봉사 일정 목록 조회 API를 개발하였습니다.
- 아래와 같은 항목을 추가하였습니다.
> - `ScheduleRepository`에 `findBy()` 메서드 추가
> - `GetScheduleListResponse` `DTO` 추가
> - `GetScheduleListService` 추가
> - `ScheduleController`에 `getScheduleList` 메서드 추가
