### PR TITLE
merge: Add .dockerignore file for optimized docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.gitignore
+.gitattributes
+.github
+
+.env
+.env.*
+
+.DS_Store


### PR DESCRIPTION
## #️연관된 이슈

#58 

## 작업 내용

Exclude unnecessary files from Docker build context to reduce build size and improve performance. Files that are already excluded by .gitignore are not included.
