### PR TITLE
merge: Update base Docker image to eclipse-temurin 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17 AS build
+FROM eclipse-temurin:17-jdk-alpine AS build
 
 WORKDIR /app
 COPY build.gradle* settings.gradle* ./
@@ -9,7 +9,8 @@ RUN chmod +x gradlew && ./gradlew dependencies --no-daemon
 COPY src src
 RUN ./gradlew bootJar --no-daemon
 
-FROM amazoncorretto:17-alpine
+FROM eclipse-temurin:17-jre-alpine
+
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
 


### PR DESCRIPTION
## #️연관된 이슈

#62 

## 작업 내용

Switch from `amazoncorretto:17` to `eclipse-temurin:17-jdk-alpine` for the build stage and from `amazoncorretto:17-alpine` to `eclipse-temurin:17-jre-alpine` for the runtime stage.

This change ensures we use a consistent and readily available base image for our Docker builds.


