### PR TITLE
알림 생성 기능 개발

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### Kotlin ###
 .kotlin
+
+### FireBase ###
+/src/main/resources/firebase/firebase_service_key.json

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,8 @@ dependencies {
     implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
     implementation("io.github.openfeign:feign-httpclient:13.5")
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    implementation("com.google.firebase:firebase-admin:6.8.1")
+    implementation("com.squareup.okhttp3:okhttp:4.9.1")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
     runtimeOnly("com.mysql:mysql-connector-j")

--- a/src/main/kotlin/org/example/root_be/domain/auth/presentation/dto/request/LoginRequest.kt
+++ b/src/main/kotlin/org/example/root_be/domain/auth/presentation/dto/request/LoginRequest.kt
@@ -3,6 +3,8 @@ package org.example.root_be.domain.auth.presentation.dto.request
 import jakarta.validation.constraints.NotBlank
 
 data class LoginRequest(
+    val fcmToken: String?,
+
     @NotBlank(message = "xquareId는 필수 값입니다")
     val xquareId: String,
 

--- a/src/main/kotlin/org/example/root_be/domain/auth/service/LoginService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/auth/service/LoginService.kt
@@ -52,7 +52,8 @@ class LoginService(
                 grade = userInfo.grade,
                 classNum = userInfo.classNum,
                 userRole = role,
-                totalVolunteerTime = 0
+                totalVolunteerTime = 0,
+                fcmToken = loginRequest.fcmToken
             )
         )
 

--- a/src/main/kotlin/org/example/root_be/domain/fcm/FcmMessage.kt
+++ b/src/main/kotlin/org/example/root_be/domain/fcm/FcmMessage.kt
@@ -1,0 +1,16 @@
+package org.example.root_be.domain.fcm
+
+data class FcmMessage(
+    val validateOnly: Boolean = false,
+    val message: Message
+) {
+    data class Message(
+        val alarm: alarm,
+        val fcmToken: String
+    )
+
+    data class alarm(
+        val title: String,
+        val body: String
+    )
+}

--- a/src/main/kotlin/org/example/root_be/domain/fcm/presentation/dto/request/MessageRequest.kt
+++ b/src/main/kotlin/org/example/root_be/domain/fcm/presentation/dto/request/MessageRequest.kt
@@ -1,0 +1,14 @@
+package org.example.root_be.domain.fcm.presentation.dto.request
+
+import jakarta.validation.constraints.NotBlank
+import org.hibernate.validator.constraints.Length
+
+data class MessageRequest(
+    @field:NotBlank(message = "제목을 비워둘 수 없습니다.")
+    @field:Length(min = 1, max = 30, message = "제목은 최소 1글자, 최대 30글자까지 작성 가능합니다.")
+    val title: String,
+
+    @field:NotBlank(message = "설명을 비워둘 수 없습니다.")
+    @field:Length(min = 1, max = 20, message = "설명은 최소 1글자, 최대 20글자까지 작성 가능합니다.")
+    val body: String
+)

--- a/src/main/kotlin/org/example/root_be/domain/fcm/service/FirebaseCloudMessageService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/fcm/service/FirebaseCloudMessageService.kt
@@ -1,0 +1,94 @@
+package org.example.root_be.domain.fcm.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.auth.oauth2.GoogleCredentials
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.example.root_be.domain.fcm.FcmMessage
+import org.example.root_be.domain.notification.domain.Notification
+import org.example.root_be.domain.notification.presentation.dto.request.generateNotificationRequest
+import org.example.root_be.domain.notification.domain.repository.NotificationRepository
+import org.example.root_be.domain.user.domain.repository.UserRepository
+import org.springframework.core.io.ClassPathResource
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+
+@Service
+class FirebaseCloudMessageService(
+    private val objectMapper: ObjectMapper,
+    private val userRepository: UserRepository,
+    private val notificationRepository: NotificationRepository
+) {
+    companion object {
+        const val API_URL = "https://fcm.googleapis.com/v1/projects/root-15624/messages:send"
+    }
+
+    private fun getAccessToken(): String {
+        val firebaseConfigPath = "firebase/firebase_service_key.json"
+        val credentials = GoogleCredentials
+            .fromStream(ClassPathResource(firebaseConfigPath).inputStream)
+            .createScoped(listOf("https://www.googleapis.com/auth/cloud-platform"))
+        credentials.refreshIfExpired()
+        return credentials.accessToken.tokenValue
+    }
+
+    private fun sendDirectTo(
+        fcmToken: String,
+        title: String,
+        body: String
+    ) {
+        val message = makeMessage(fcmToken, title, body)
+
+        val client = OkHttpClient()
+        val requestBody = message
+            .toRequestBody("application/json; charset=utf-8".toMediaType())
+        val request = Request.Builder()
+            .url(API_URL)
+            .post(requestBody)
+            .addHeader("Authorization", "Bearer ${getAccessToken()}")
+            .build()
+        val response = client.newCall(request).execute()
+
+        println(response.body!!.string())
+    }
+
+    @Async
+    fun sendAllUsers(
+        request: generateNotificationRequest
+    ) {
+        saveNotification(request)
+
+        val title = request.title
+        val body = request.body
+
+        userRepository.findAll()
+            .forEach {
+                it.fcmToken?.let { token ->
+                    sendDirectTo(token, title, body)
+                }
+            }
+    }
+
+    private fun makeMessage(
+        fcmToken: String,
+        title: String,
+        body: String
+    ): String {
+        val alarm = FcmMessage.alarm(title = title, body = body)
+        val message = FcmMessage.Message(fcmToken = fcmToken, alarm = alarm)
+        return objectMapper.writeValueAsString(FcmMessage(message = message))
+    }
+
+    private fun saveNotification(
+        request: generateNotificationRequest
+    ) {
+        notificationRepository.save(
+            Notification(
+                title = request.title,
+                body = request.body
+            )
+        )
+    }
+}

--- a/src/main/kotlin/org/example/root_be/domain/notification/domain/Notification.kt
+++ b/src/main/kotlin/org/example/root_be/domain/notification/domain/Notification.kt
@@ -1,0 +1,21 @@
+package org.example.root_be.domain.notification.domain
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "NOTIFICATION")
+class Notification(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(name = "title", nullable = false)
+    val title: String,
+
+    @Column(name = "body")
+    val body: String,
+
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime = LocalDateTime.now()
+)

--- a/src/main/kotlin/org/example/root_be/domain/notification/domain/repository/NotificationRepository.kt
+++ b/src/main/kotlin/org/example/root_be/domain/notification/domain/repository/NotificationRepository.kt
@@ -1,0 +1,6 @@
+package org.example.root_be.domain.notification.domain.repository
+
+import org.example.root_be.domain.notification.domain.Notification
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface NotificationRepository: JpaRepository<Notification, Long>

--- a/src/main/kotlin/org/example/root_be/domain/notification/presentation/NotificationController.kt
+++ b/src/main/kotlin/org/example/root_be/domain/notification/presentation/NotificationController.kt
@@ -1,0 +1,21 @@
+package org.example.root_be.domain.notification.presentation
+
+import org.example.root_be.domain.fcm.service.FirebaseCloudMessageService
+import org.example.root_be.domain.notification.presentation.dto.request.generateNotificationRequest
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/notifications")
+class NotificationController(
+    private val firebaseCloudMessageService: FirebaseCloudMessageService
+) {
+    @PostMapping
+    fun generateNotification(
+        @RequestBody request: generateNotificationRequest
+    ) {
+        firebaseCloudMessageService.sendAllUsers(request)
+    }
+}

--- a/src/main/kotlin/org/example/root_be/domain/notification/presentation/dto/request/generateNotificationRequest.kt
+++ b/src/main/kotlin/org/example/root_be/domain/notification/presentation/dto/request/generateNotificationRequest.kt
@@ -1,9 +1,9 @@
-package org.example.root_be.domain.fcm.presentation.dto.request
+package org.example.root_be.domain.notification.presentation.dto.request
 
 import jakarta.validation.constraints.NotBlank
 import org.hibernate.validator.constraints.Length
 
-data class MessageRequest(
+data class generateNotificationRequest(
     @field:NotBlank(message = "제목을 비워둘 수 없습니다.")
     @field:Length(min = 1, max = 30, message = "제목은 최소 1글자, 최대 30글자까지 작성 가능합니다.")
     val title: String,

--- a/src/main/kotlin/org/example/root_be/domain/user/domain/User.kt
+++ b/src/main/kotlin/org/example/root_be/domain/user/domain/User.kt
@@ -35,7 +35,10 @@ class User(
 
     @OneToOne
     @JoinColumn(name = "volunteer_role_id")
-    var volunteerRole: VolunteerRole? = null
+    var volunteerRole: VolunteerRole? = null,
+
+    @Column(name = "fcm_token")
+    var fcmToken: String?
 ) {
     fun addVolunteerTime(time: Int) {
         this.totalVolunteerTime += time


### PR DESCRIPTION
## #️연관된 이슈

> #71

## 작업 내용

> `FCM`을 통해  푸쉬 알림 생성 API를 개발하였습니다.

> `User` 엔티티에 `fcmToken` 필드 추가
> `LoginRequest`에 `fcmToken` 필드 추가 후, `LoginService`에 `fcmToken` 저장 로직 추가
> `FirebaseCloudMessageService` 추가
> `Notification` 엔티티, `NotificationRepository`, `NotificationController` 추가
> `FirebaseCloudMessageService`에 푸쉬 알림 전송 로직과 함께 알림 저장 기능 추가

추후 리팩토링 진행 예정입니다.