### PR TITLE
feat: 마이페이지 API 구현

### DIFF
--- a/src/main/kotlin/org/example/root_be/domain/applications/domain/VolunteerApplication.kt
+++ b/src/main/kotlin/org/example/root_be/domain/applications/domain/VolunteerApplication.kt
@@ -23,7 +23,7 @@ class VolunteerApplication(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "role_id")
-    val volunteerRole: VolunteerRole? = null,
+    var volunteerRole: VolunteerRole? = null,
 
     @Column(nullable = false)
     var isApplied: Boolean = false,

--- a/src/main/kotlin/org/example/root_be/domain/applications/domain/repository/VolunteerApplicationRepository.kt
+++ b/src/main/kotlin/org/example/root_be/domain/applications/domain/repository/VolunteerApplicationRepository.kt
@@ -1,10 +1,13 @@
 package org.example.root_be.domain.applications.domain.repository
 
 import org.example.root_be.domain.applications.domain.VolunteerApplication
+import org.example.root_be.domain.post.domain.VolunteerPost
+import org.example.root_be.domain.user.domain.User
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
 interface VolunteerApplicationRepository : JpaRepository<VolunteerApplication, Long> {
     fun findAllByVolunteerPostId(postId: Long): List<VolunteerApplication>
+    fun findByUserAndVolunteerPost(user: User, volunteerPost: VolunteerPost): VolunteerApplication?
 }

--- a/src/main/kotlin/org/example/root_be/domain/role/service/GrantRoleService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/role/service/GrantRoleService.kt
@@ -1,5 +1,7 @@
 package org.example.root_be.domain.role.service
 
+import org.example.root_be.domain.applications.domain.repository.VolunteerApplicationRepository
+import org.example.root_be.domain.applications.exception.ApplicationNotFoundException
 import org.example.root_be.domain.post.facade.VolunteerFacade
 import org.example.root_be.domain.role.exception.VolunteerRoleNotFoundException
 import org.example.root_be.domain.role.presentation.dto.request.GranRoleRequest
@@ -10,7 +12,8 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class GrantRoleService(
     private val userFacade: UserFacade,
-    private val volunteerFacade: VolunteerFacade
+    private val volunteerFacade: VolunteerFacade,
+    private val volunteerApplicationRepository: VolunteerApplicationRepository
 ) {
     @Transactional
     fun execute(
@@ -24,6 +27,9 @@ class GrantRoleService(
         val volunteerRole = volunteerRoles.find { it.title == request.role }
             ?: throw VolunteerRoleNotFoundException
 
-        user.grantVolunteerRole(volunteerRole)
+        val application = volunteerApplicationRepository.findByUserAndVolunteerPost(user, post)
+            ?: throw ApplicationNotFoundException
+
+        application.volunteerRole = volunteerRole
     }
 }

--- a/src/main/kotlin/org/example/root_be/domain/teacher_role/domain/TeacherRole.kt
+++ b/src/main/kotlin/org/example/root_be/domain/teacher_role/domain/TeacherRole.kt
@@ -1,0 +1,19 @@
+package org.example.root_be.domain.teacher_role.domain
+
+import jakarta.persistence.*
+import org.example.root_be.domain.user.domain.User
+
+@Entity
+@Table(name = "TEACHER_ROLE")
+class TeacherRole(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
+
+    @Column(nullable = false)
+    val title: String
+)

--- a/src/main/kotlin/org/example/root_be/domain/user/domain/User.kt
+++ b/src/main/kotlin/org/example/root_be/domain/user/domain/User.kt
@@ -1,7 +1,9 @@
 package org.example.root_be.domain.user.domain
 
 import jakarta.persistence.*
+import org.example.root_be.domain.applications.domain.VolunteerApplication
 import org.example.root_be.domain.role.domain.VolunteerRole
+import org.example.root_be.domain.teacher_role.domain.TeacherRole
 import org.example.root_be.domain.user.domain.type.Role
 
 @Entity
@@ -26,9 +28,6 @@ class User(
     @Column(name = "class_num", nullable = false)
     var classNum: Int,
 
-    @Column(name = "area", nullable = false)
-    var area: String,
-
     @Enumerated(EnumType.STRING)
     @Column(name = "user_role", nullable = false)
     var userRole: Role,
@@ -36,20 +35,16 @@ class User(
     @Column(name = "total_volunteer_time", nullable = false)
     var totalVolunteerTime: Int,
 
-    @OneToOne
-    @JoinColumn(name = "volunteer_role_id")
-    var volunteerRole: VolunteerRole? = null,
+    @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val volunteerApplications: List<VolunteerApplication> = listOf(),
+
+    @OneToMany(mappedBy = "teacher_role", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val teacherRoles: List<TeacherRole> = listOf(),
 
     @Column(name = "fcm_token")
     var fcmToken: String?
 ) {
     fun addVolunteerTime(time: Int) {
         this.totalVolunteerTime += time
-    }
-
-    fun grantVolunteerRole(
-        volunteerRole: VolunteerRole
-    ) {
-        this.volunteerRole = volunteerRole
     }
 }

--- a/src/main/kotlin/org/example/root_be/domain/user/domain/User.kt
+++ b/src/main/kotlin/org/example/root_be/domain/user/domain/User.kt
@@ -26,6 +26,9 @@ class User(
     @Column(name = "class_num", nullable = false)
     var classNum: Int,
 
+    @Column(name = "area", nullable = false)
+    var area: String,
+
     @Enumerated(EnumType.STRING)
     @Column(name = "user_role", nullable = false)
     var userRole: Role,

--- a/src/main/kotlin/org/example/root_be/domain/user/presentation/dto/response/MypageResponse.kt
+++ b/src/main/kotlin/org/example/root_be/domain/user/presentation/dto/response/MypageResponse.kt
@@ -1,7 +1,11 @@
 package org.example.root_be.domain.user.presentation.dto.response
 
+import com.fasterxml.jackson.annotation.JsonInclude
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class MypageResponse (
-    val studentNumber: Int,
-    val studentName: String,
-    val volunteerTime: Int
+    val name: String,
+    val number: Int?,
+    val area: String,
+    val volunteerTime: Int?
 )

--- a/src/main/kotlin/org/example/root_be/domain/user/presentation/dto/response/MypageResponse.kt
+++ b/src/main/kotlin/org/example/root_be/domain/user/presentation/dto/response/MypageResponse.kt
@@ -6,6 +6,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
 data class MypageResponse (
     val name: String,
     val number: Int?,
-    val area: String,
+    val area: List<String>,
     val volunteerTime: Int?
 )

--- a/src/main/kotlin/org/example/root_be/domain/user/service/MypageService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/user/service/MypageService.kt
@@ -1,18 +1,28 @@
 package org.example.root_be.domain.user.service
 
+import org.example.root_be.domain.user.domain.type.Role
 import org.example.root_be.domain.user.facade.UserFacade
 import org.example.root_be.domain.user.presentation.dto.response.MypageResponse
 import org.springframework.stereotype.Service
 
 @Service
-class MypageService (
+class MypageService(
     private val userFacade: UserFacade
-){
+) {
     fun execute(): MypageResponse = userFacade.getCurrentUser().let { user ->
-        MypageResponse(
-            studentNumber = user.num,
-            studentName = user.name,
-            volunteerTime = user.totalVolunteerTime
-        )
+        when (user.userRole) {
+            Role.STUDENT -> MypageResponse(
+                name = user.name,
+                number = user.num,
+                area = user.area,
+                volunteerTime = user.totalVolunteerTime
+            )
+            Role.ADMIN -> MypageResponse(
+                name = user.name,
+                number = null,
+                area = user.area,
+                volunteerTime = null
+            )
+        }
     }
 }

--- a/src/main/kotlin/org/example/root_be/domain/user/service/MypageService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/user/service/MypageService.kt
@@ -14,13 +14,17 @@ class MypageService(
             Role.STUDENT -> MypageResponse(
                 name = user.name,
                 number = user.num,
-                area = user.area,
+                area = user.volunteerApplications
+                    .mapNotNull { application -> application.volunteerRole?.title }
+                    .distinct(),
                 volunteerTime = user.totalVolunteerTime
             )
             Role.ADMIN -> MypageResponse(
                 name = user.name,
                 number = null,
-                area = user.area,
+                area = user.teacherRoles
+                    .map { role -> role.title }
+                    .distinct(),
                 volunteerTime = null
             )
         }


### PR DESCRIPTION
## #️연관된 이슈

#75  

## 작업 내용

마이페이지에서 유저 정보를 가져오는 API를 구현한다.
- User 엔티티에 area 필드 추가
- MypageResponse에 name, number, area, volunteerTime 필드 추가
- Role에 따라 다른 정보를 반환하도록 구현
- STUDENT의 경우 name, number, area, volunteerTime 필드를 반환
- ADMIN의 경우 name, area 필드만 반환
- 기존의 studentNumber, studentName, volunteerTime 필드 제거

