### PR TITLE
봉사 게시물 관련 로직 리팩토링

### DIFF
--- a/src/main/kotlin/org/example/root_be/domain/post/domain/VolunteerPost.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/domain/VolunteerPost.kt
@@ -2,6 +2,7 @@ package org.example.root_be.domain.post.domain
 
 import jakarta.persistence.*
 import org.example.root_be.domain.detail.domain.VolunteerDetail
+import org.example.root_be.domain.post_day.domain.PostDay
 import org.example.root_be.domain.role.domain.VolunteerRole
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -33,8 +34,9 @@ class VolunteerPost(
     @Column(name = "work_end_date")
     var workEndDate: LocalDate?,
 
-    @Column(name = "day_of_week")
-    var dayOfWeek: String?,
+    @OneToMany(mappedBy = "volunteerPost", cascade = [CascadeType.ALL], orphanRemoval = true)
+    @JoinColumn(name = "post_id")
+    var dayOfWeek: MutableList<PostDay> = mutableListOf(),
 
     @Column(name = "is_regular", nullable = false)
     var isRegular: Boolean,
@@ -58,7 +60,7 @@ class VolunteerPost(
         applicationEndDate: LocalDate,
         workStartDate: LocalDate?,
         workEndDate: LocalDate?,
-        dayOfWeek: String?,
+        dayOfWeek: MutableList<PostDay>,
         personnel: String,
         updatedAt: LocalDateTime
     ) {

--- a/src/main/kotlin/org/example/root_be/domain/post/domain/VolunteerPost.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/domain/VolunteerPost.kt
@@ -60,7 +60,6 @@ class VolunteerPost(
         applicationEndDate: LocalDate,
         workStartDate: LocalDate?,
         workEndDate: LocalDate?,
-        dayOfWeek: MutableList<PostDay>,
         personnel: String,
         updatedAt: LocalDateTime
     ) {
@@ -70,7 +69,6 @@ class VolunteerPost(
         this.applicationEndDate = applicationEndDate
         this.workStartDate = workStartDate
         this.workEndDate = workEndDate
-        this.dayOfWeek = dayOfWeek
         this.personnel = personnel
         this.updatedAt = LocalDateTime.now()
     }

--- a/src/main/kotlin/org/example/root_be/domain/post/domain/VolunteerPost.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/domain/VolunteerPost.kt
@@ -50,7 +50,7 @@ class VolunteerPost(
     @Column(name = "updated_at")
     var updatedAt: LocalDateTime = LocalDateTime.now(),
 
-    @OneToMany(mappedBy = "volunteerPost", cascade = [CascadeType.ALL])
+    @OneToMany(mappedBy = "volunteerPost", cascade = [CascadeType.ALL], orphanRemoval = true)
     val roles: List<VolunteerRole> = listOf()
 ) {
     fun modifyPost(

--- a/src/main/kotlin/org/example/root_be/domain/post/domain/VolunteerPost.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/domain/VolunteerPost.kt
@@ -35,7 +35,6 @@ class VolunteerPost(
     var workEndDate: LocalDate?,
 
     @OneToMany(mappedBy = "volunteerPost", cascade = [CascadeType.ALL], orphanRemoval = true)
-    @JoinColumn(name = "post_id")
     var dayOfWeek: MutableList<PostDay> = mutableListOf(),
 
     @Column(name = "is_regular", nullable = false)

--- a/src/main/kotlin/org/example/root_be/domain/post/presentation/dto/request/GenerateVolunteerPostRequest.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/presentation/dto/request/GenerateVolunteerPostRequest.kt
@@ -2,6 +2,7 @@ package org.example.root_be.domain.post.presentation.dto.request
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import jakarta.validation.constraints.NotBlank
+import org.example.root_be.domain.post_day.domain.PostDay
 import org.hibernate.validator.constraints.Length
 import org.jetbrains.annotations.NotNull
 import java.time.LocalDate
@@ -23,7 +24,7 @@ data class GenerateVolunteerPostRequest(
 
     val workDate: List<WorkDateElement>?,
 
-    val dayOfWeek: String?,
+    val dayOfWeek: MutableList<DayOfWeekElement>,
 
     @field:NotNull
     val place: String,
@@ -54,5 +55,10 @@ data class GenerateVolunteerPostRequest(
     data class RoleElement(
         val id: Long,
         val title: String
+    )
+
+    data class DayOfWeekElement(
+        val id: Long,
+        val dayOfWeek: String
     )
 }

--- a/src/main/kotlin/org/example/root_be/domain/post/presentation/dto/request/ModifyVolunteerPostRequest.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/presentation/dto/request/ModifyVolunteerPostRequest.kt
@@ -23,7 +23,7 @@ data class ModifyVolunteerPostRequest(
 
     val workDate: List<WorkDateElement>?,
 
-    val dayOfWeek: List<DayOfWeekElement>?,
+    val dayOfWeek: MutableList<DayOfWeekElement>?,
 
     @field:NotNull
     val place: String,

--- a/src/main/kotlin/org/example/root_be/domain/post/presentation/dto/request/ModifyVolunteerPostRequest.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/presentation/dto/request/ModifyVolunteerPostRequest.kt
@@ -23,7 +23,7 @@ data class ModifyVolunteerPostRequest(
 
     val workDate: List<WorkDateElement>?,
 
-    val dayOfWeek: String?,
+    val dayOfWeek: List<DayOfWeekElement>?,
 
     @field:NotNull
     val place: String,
@@ -54,5 +54,10 @@ data class ModifyVolunteerPostRequest(
     data class RoleElement(
         val roleId: Long?,
         val title: String
+    )
+
+    data class DayOfWeekElement(
+        val dayId: Long,
+        val dayOfWeek: String
     )
 }

--- a/src/main/kotlin/org/example/root_be/domain/post/presentation/dto/response/GetVolunteerPostResponse.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/presentation/dto/response/GetVolunteerPostResponse.kt
@@ -1,18 +1,20 @@
 package org.example.root_be.domain.post.presentation.dto.response
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonInclude
 import org.example.root_be.domain.detail.domain.VolunteerDetail
 import org.example.root_be.domain.post.domain.VolunteerPost
 import org.example.root_be.domain.post_day.domain.PostDay
 import java.time.LocalDate
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class GetVolunteerPostResponse(
     val id: Long,
     val title: String,
     val activityDetails: String?,
     val applicationPeriod: List<ApplicationPeriodResponse>,
     val workDate: List<WorkDateResponse>?,
-    val dayOfWeek: List<DayOfWeekResponse>,
+    val dayOfWeek: List<DayOfWeekResponse>?,
     val place: String,
     val time: String,
     val personnel: String,

--- a/src/main/kotlin/org/example/root_be/domain/post/presentation/dto/response/GetVolunteerPostResponse.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/presentation/dto/response/GetVolunteerPostResponse.kt
@@ -23,7 +23,6 @@ data class GetVolunteerPostResponse(
     constructor(
         volunteerPost: VolunteerPost,
         volunteerDetail: VolunteerDetail,
-        postDay: PostDay
     ): this(
         id = volunteerPost.id,
         title = volunteerPost.title,

--- a/src/main/kotlin/org/example/root_be/domain/post/presentation/dto/response/GetVolunteerPostResponse.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/presentation/dto/response/GetVolunteerPostResponse.kt
@@ -3,6 +3,7 @@ package org.example.root_be.domain.post.presentation.dto.response
 import com.fasterxml.jackson.annotation.JsonFormat
 import org.example.root_be.domain.detail.domain.VolunteerDetail
 import org.example.root_be.domain.post.domain.VolunteerPost
+import org.example.root_be.domain.post_day.domain.PostDay
 import java.time.LocalDate
 
 data class GetVolunteerPostResponse(
@@ -11,7 +12,7 @@ data class GetVolunteerPostResponse(
     val activityDetails: String?,
     val applicationPeriod: List<ApplicationPeriodResponse>,
     val workDate: List<WorkDateResponse>?,
-    val dayOfWeek: String?,
+    val dayOfWeek: List<DayOfWeekResponse>,
     val place: String,
     val time: String,
     val personnel: String,
@@ -19,14 +20,15 @@ data class GetVolunteerPostResponse(
 ) {
     constructor(
         volunteerPost: VolunteerPost,
-        volunteerDetail: VolunteerDetail
+        volunteerDetail: VolunteerDetail,
+        postDay: PostDay
     ): this(
         id = volunteerPost.id,
         title = volunteerPost.title,
         activityDetails = volunteerDetail.activityDetails,
         applicationPeriod = listOf(ApplicationPeriodResponse(volunteerPost)),
         workDate = listOf(WorkDateResponse(volunteerPost)),
-        dayOfWeek = volunteerPost.dayOfWeek,
+        dayOfWeek = volunteerPost.dayOfWeek.map { DayOfWeekResponse(it.id, it.dayOfWeek) },
         place = volunteerDetail.place,
         time = volunteerDetail.time,
         personnel = volunteerPost.personnel,
@@ -59,5 +61,10 @@ data class GetVolunteerPostResponse(
     data class RoleResponse(
         val id: Long,
         val title: String
+    )
+
+    data class DayOfWeekResponse(
+        val id: Long,
+        val dayOfWeek: String
     )
 }

--- a/src/main/kotlin/org/example/root_be/domain/post/service/GenerateVolunteerPostService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/service/GenerateVolunteerPostService.kt
@@ -8,6 +8,8 @@ import org.example.root_be.domain.role.domain.repository.RoleRepository
 import org.example.root_be.domain.post.domain.VolunteerPost
 import org.example.root_be.domain.post.domain.repository.VolunteerPostRepository
 import org.example.root_be.domain.post.presentation.dto.request.GenerateVolunteerPostRequest
+import org.example.root_be.domain.post_day.domain.PostDay
+import org.example.root_be.domain.post_day.domain.repository.PostDayRepository
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 
@@ -15,7 +17,8 @@ import java.time.LocalDateTime
 class GenerateVolunteerPostService(
     private val volunteerPostRepository: VolunteerPostRepository,
     private val roleRepository: RoleRepository,
-    private val volunteerDetailRepository: VolunteerDetailRepository
+    private val volunteerDetailRepository: VolunteerDetailRepository,
+    private val postDayRepository: PostDayRepository
 ) {
     @Transactional
     fun execute(
@@ -33,6 +36,7 @@ class GenerateVolunteerPostService(
                 )
             }
 
+
         val volunteerPost =
             request.run {
                 VolunteerPost(
@@ -43,13 +47,21 @@ class GenerateVolunteerPostService(
                     applicationEndDate = applicationDate.endDate,
                     workStartDate = workDate?.startDate,
                     workEndDate = workDate?.endDate,
-                    dayOfWeek = dayOfWeek,
                     personnel = personnel,
                     createdAt = LocalDateTime.now(),
                 )
             }
 
+        val dayOfWeek =
+            request.dayOfWeek.map {
+                PostDay(
+                    dayOfWeek = it.dayOfWeek,
+                    volunteerPost = volunteerPost
+                )
+            }
+
         saveRoles(request, volunteerPost)
+        postDayRepository.saveAll(dayOfWeek)
         volunteerDetailRepository.save(detail)
         volunteerPostRepository.save(volunteerPost)
     }

--- a/src/main/kotlin/org/example/root_be/domain/post/service/GetVolunteerPostDetailsService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/service/GetVolunteerPostDetailsService.kt
@@ -1,17 +1,17 @@
 package org.example.root_be.domain.post.service
 
-import jakarta.transaction.Transactional
 import org.example.root_be.domain.detail.facade.DetailFacade
 import org.example.root_be.domain.post.facade.VolunteerFacade
 import org.example.root_be.domain.post.presentation.dto.response.GetVolunteerPostResponse
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class GetVolunteerPostDetailsService(
     private val volunteerFacade: VolunteerFacade,
     private val detailsFacade: DetailFacade
 ) {
-    @Transactional
+    @Transactional(readOnly = true)
     fun execute(
         postId: Long
     ): GetVolunteerPostResponse {

--- a/src/main/kotlin/org/example/root_be/domain/post/service/GetVolunteerPostListService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/service/GetVolunteerPostListService.kt
@@ -3,11 +3,13 @@ package org.example.root_be.domain.post.service
 import org.example.root_be.domain.post.domain.repository.VolunteerPostRepository
 import org.example.root_be.domain.post.presentation.dto.response.GetVolunteerPostsResponse
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class GetVolunteerPostListService(
     private val volunteerPostRepository: VolunteerPostRepository
 ) {
+    @Transactional(readOnly = true)
     fun execute(): GetVolunteerPostsResponse {
         return GetVolunteerPostsResponse(
             volunteerPostRepository.findBy()

--- a/src/main/kotlin/org/example/root_be/domain/post/service/ModifyVolunteerPostService.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post/service/ModifyVolunteerPostService.kt
@@ -7,6 +7,9 @@ import org.example.root_be.domain.post.domain.VolunteerPost
 import org.example.root_be.domain.post.domain.repository.VolunteerPostRepository
 import org.example.root_be.domain.post.facade.VolunteerFacade
 import org.example.root_be.domain.post.presentation.dto.request.ModifyVolunteerPostRequest
+import org.example.root_be.domain.post_day.domain.PostDay
+import org.example.root_be.domain.post_day.domain.repository.PostDayRepository
+import org.example.root_be.domain.post_day.exception.PostDayNotFoundException
 import org.example.root_be.domain.role.domain.VolunteerRole
 import org.example.root_be.domain.role.domain.repository.RoleRepository
 import org.example.root_be.domain.role.exception.VolunteerRoleNotFoundException
@@ -19,7 +22,8 @@ class ModifyVolunteerPostService(
     private val volunteerFacade: VolunteerFacade,
     private val roleRepository: RoleRepository,
     private val detailFacade: DetailFacade,
-    private val volunteerDetailRepository: VolunteerDetailRepository
+    private val volunteerDetailRepository: VolunteerDetailRepository,
+    private val postDayRepository: PostDayRepository
 ) {
     @Transactional
     fun execute(
@@ -38,13 +42,13 @@ class ModifyVolunteerPostService(
             applicationEndDate = applicationDate.endDate,
             workStartDate = workDate?.startDate,
             workEndDate = workDate?.endDate,
-            dayOfWeek = request.dayOfWeek,
             personnel = request.personnel,
             updatedAt = LocalDateTime.now()
         )
 
         saveDetail(request, post)
         saveRoles(request, post)
+        saveDayOfWeek(request, post)
         volunteerPostRepository.save(post)
     }
 
@@ -97,6 +101,33 @@ class ModifyVolunteerPostService(
 
         if (newRoles.isNotEmpty()) {
             roleRepository.saveAll(newRoles)
+        }
+    }
+
+    @Transactional
+    fun saveDayOfWeek(
+        request: ModifyVolunteerPostRequest,
+        post: VolunteerPost
+    ) {
+        val modifyDayOfWeekIds = request.dayOfWeek
+            ?.map { it.dayId }?.toSet()
+            ?: setOf()
+
+        val existingPostDays = postDayRepository.findAllByVolunteerPost(post)
+
+        val deleteDayOfWeeks = existingPostDays.filter { (it.id !in modifyDayOfWeekIds) }
+        postDayRepository.deleteAll(deleteDayOfWeeks)
+
+        val addDayOfWeeks = mutableListOf<PostDay>()
+
+        request.dayOfWeek?.forEach { dayOfWeekRequest ->
+            existingPostDays.find {it.id == dayOfWeekRequest.dayId}
+                ?.apply { dayOfWeek = dayOfWeekRequest.dayOfWeek }
+                ?: throw PostDayNotFoundException
+        }
+
+        if (addDayOfWeeks.isNotEmpty()) {
+            postDayRepository.saveAll(addDayOfWeeks)
         }
     }
 }

--- a/src/main/kotlin/org/example/root_be/domain/post_day/domain/PostDay.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post_day/domain/PostDay.kt
@@ -1,0 +1,19 @@
+package org.example.root_be.domain.post_day.domain
+
+import jakarta.persistence.*
+import org.example.root_be.domain.post.domain.VolunteerPost
+
+@Entity
+@Table(name = "POST_DAY")
+class PostDay(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "volunteer_post_id")
+    val volunteerPost: VolunteerPost,
+
+    @Column(name = "day_of_week", nullable = false)
+    var dayOfWeek: String
+)

--- a/src/main/kotlin/org/example/root_be/domain/post_day/domain/repository/PostDayRepository.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post_day/domain/repository/PostDayRepository.kt
@@ -1,0 +1,6 @@
+package org.example.root_be.domain.post_day.domain.repository
+
+import org.example.root_be.domain.post_day.domain.PostDay
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PostDayRepository: JpaRepository<PostDay, Long>

--- a/src/main/kotlin/org/example/root_be/domain/post_day/domain/repository/PostDayRepository.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post_day/domain/repository/PostDayRepository.kt
@@ -1,6 +1,9 @@
 package org.example.root_be.domain.post_day.domain.repository
 
+import org.example.root_be.domain.post.domain.VolunteerPost
 import org.example.root_be.domain.post_day.domain.PostDay
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface PostDayRepository: JpaRepository<PostDay, Long>
+interface PostDayRepository: JpaRepository<PostDay, Long> {
+    fun findAllByVolunteerPost(post: VolunteerPost): List<PostDay>
+}

--- a/src/main/kotlin/org/example/root_be/domain/post_day/exception/PostDayNotFoundException.kt
+++ b/src/main/kotlin/org/example/root_be/domain/post_day/exception/PostDayNotFoundException.kt
@@ -1,0 +1,6 @@
+package org.example.root_be.domain.post_day.exception
+
+import org.example.root_be.global.err.exception.CustomException
+import org.example.root_be.global.err.exception.ErrorCode
+
+object PostDayNotFoundException: CustomException(ErrorCode.POST_DAY_NOT_FOUND)

--- a/src/main/kotlin/org/example/root_be/domain/user/domain/User.kt
+++ b/src/main/kotlin/org/example/root_be/domain/user/domain/User.kt
@@ -38,7 +38,7 @@ class User(
     @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], orphanRemoval = true)
     val volunteerApplications: List<VolunteerApplication> = listOf(),
 
-    @OneToMany(mappedBy = "teacher_role", cascade = [CascadeType.ALL], orphanRemoval = true)
+    @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true)
     val teacherRoles: List<TeacherRole> = listOf(),
 
     @Column(name = "fcm_token")

--- a/src/main/kotlin/org/example/root_be/global/err/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/example/root_be/global/err/exception/ErrorCode.kt
@@ -12,6 +12,7 @@ enum class ErrorCode(
     VOLUNTEER_DETAIL_NOT_FOUND("Detail Not Found", 404),
     SCHEDULE_NOT_FOUND("Schedule Not Found", 404),
     USER_NOT_FOUND("User Not Found", 404),
+    POST_DAY_NOT_FOUND("Post Day Not Found", 404),
     INVALID_PASSWORD("Invalid Password", 401),
     FEIGN_BAD_REQUEST("External API request is invalid.", 400),
     FEIGN_SERVER_ERROR("An external server error occurred.", 500),


### PR DESCRIPTION
## 연관된 이슈 번호

> ex) #79

## 작업 내용

> 봉사 게시물 생성, 수정, 상세 조회 로직을 리팩토링하였습니다.
> `PostDay`, `PostDayRepository` 추가
> `VolunteerPost`와 `PostDay` 연관관계 설정
> 게시물 관련 `DTO`들의 `dayOfWeek` 필드를 `List` 형태로 수정
> `DTO`에 맞는 생성, 상세 조회, 수정 서비스 로직 수정
